### PR TITLE
feat: implement concrete TLS Extension classes (#4)

### DIFF
--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -152,6 +152,7 @@ class TLS:
                 signature_algorithms=self._signature_algorithms,
                 alpn_protocols=getattr(tls_config, 'alpn_protocols', None),
                 use_grease=getattr(tls_config, 'use_grease', True),
+                _extensions=getattr(tls_config, 'extensions', None),
             )
 
     def handshake(self):

--- a/ja3requests/protocol/tls/config.py
+++ b/ja3requests/protocol/tls/config.py
@@ -278,7 +278,7 @@ class TlsConfig:
         extensions = "-".join([str(t) for t in ext_types])
 
         # Elliptic Curves (Supported Groups)
-        elliptic_curves = "-".join([str(group) for group in self._supported_groups])
+        elliptic_curves = "-".join([str(group) for group in self._supported_groups]) if self._supported_groups else ""
 
         # Elliptic Curve Point Formats (commonly 0 for uncompressed)
         ec_point_formats = "0"

--- a/ja3requests/protocol/tls/config.py
+++ b/ja3requests/protocol/tls/config.py
@@ -243,16 +243,39 @@ class TlsConfig:
         Generate JA3 fingerprint string based on current configuration.
         Format: TLSVersion,CipherSuites,Extensions,EllipticCurves,EllipticCurvePointFormats
         """
+        from ja3requests.protocol.tls.extensions import (  # pylint: disable=import-outside-toplevel
+            Extension,
+            SNIExtension,
+            SupportedGroupsExtension,
+            SignatureAlgorithmsExtension,
+            ALPNExtension,
+        )
+
         # TLS Version
         tls_version = str(self._tls_version)
 
         # Cipher Suites
         cipher_suites = "-".join([str(suite.value) for suite in self._cipher_suites])
 
-        # Extensions (placeholder - would need actual extension values)
-        extensions = (
-            "-".join([str(ext) for ext in self._extensions]) if self._extensions else ""
-        )
+        # Extensions: collect type IDs from Extension objects + auto-generated ones
+        ext_types = []
+        custom_types = set()
+        for ext in self._extensions:
+            if isinstance(ext, Extension):
+                ext_types.append(ext.extension_type)
+                custom_types.add(ext.extension_type)
+
+        # Auto-generated extensions (same logic as ClientHello._build_extensions)
+        if self._server_name and SNIExtension.extension_type not in custom_types:
+            ext_types.append(SNIExtension.extension_type)
+        if self._supported_groups and SupportedGroupsExtension.extension_type not in custom_types:
+            ext_types.append(SupportedGroupsExtension.extension_type)
+        if self._signature_algorithms and SignatureAlgorithmsExtension.extension_type not in custom_types:
+            ext_types.append(SignatureAlgorithmsExtension.extension_type)
+        if self._alpn_protocols and ALPNExtension.extension_type not in custom_types:
+            ext_types.append(ALPNExtension.extension_type)
+
+        extensions = "-".join([str(t) for t in ext_types])
 
         # Elliptic Curves (Supported Groups)
         elliptic_curves = "-".join([str(group) for group in self._supported_groups])

--- a/ja3requests/protocol/tls/extensions/__init__.py
+++ b/ja3requests/protocol/tls/extensions/__init__.py
@@ -14,16 +14,193 @@ enum {
 } ExtensionType;
 """
 
+import struct
 from abc import ABC, abstractmethod
 
 
 class Extension(ABC):
-    """Abstract base class for TLS extensions."""
+    """Abstract base class for TLS extensions.
+
+    Each extension encodes itself into the TLS wire format:
+        2 bytes extension_type + 2 bytes length + extension_data
+    """
 
     extension_type = None
     extension_data = b''
 
     @abstractmethod
     def encode(self):
-        """Encode the extension into bytes."""
+        """Encode the extension data (without type and length header)."""
         raise NotImplementedError("encode method must be implemented by subclass.")
+
+    def to_bytes(self):
+        """Encode the full extension with type and length header."""
+        data = self.encode()
+        return struct.pack("!HH", self.extension_type, len(data)) + data
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} type=0x{self.extension_type:04X}>"
+
+
+class SNIExtension(Extension):
+    """Server Name Indication (SNI) extension (type 0x0000).
+
+    Allows the client to indicate which hostname it is connecting to,
+    enabling the server to present the appropriate certificate.
+    """
+
+    extension_type = 0x0000
+
+    def __init__(self, server_name):
+        self.server_name = server_name
+
+    def encode(self):
+        name_bytes = self.server_name.encode('utf-8')
+        # ServerNameList: 2 bytes list length
+        #   ServerName: 1 byte name type (0 = hostname) + 2 bytes name length + name
+        sni_entry = struct.pack("!BH", 0, len(name_bytes)) + name_bytes
+        return struct.pack("!H", len(sni_entry)) + sni_entry
+
+
+class SupportedGroupsExtension(Extension):
+    """Supported Groups (Elliptic Curves) extension (type 0x000A).
+
+    Indicates the named groups (elliptic curves) the client supports
+    for key exchange.
+
+    Common group IDs:
+        23 = secp256r1, 24 = secp384r1, 25 = secp521r1,
+        29 = x25519, 30 = x448
+    """
+
+    extension_type = 0x000A
+
+    def __init__(self, groups):
+        self.groups = groups
+
+    def encode(self):
+        groups_bytes = b"".join(struct.pack("!H", g) for g in self.groups)
+        return struct.pack("!H", len(groups_bytes)) + groups_bytes
+
+
+class SignatureAlgorithmsExtension(Extension):
+    """Signature Algorithms extension (type 0x000D).
+
+    Indicates which signature/hash algorithm pairs the client supports
+    for verifying server certificates and key exchange signatures.
+
+    Common values (HashAlgorithm << 8 | SignatureAlgorithm):
+        0x0401 = RSA PKCS1 SHA256, 0x0501 = RSA PKCS1 SHA384,
+        0x0601 = RSA PKCS1 SHA512, 0x0403 = ECDSA SHA256,
+        0x0804 = RSA PSS SHA256
+    """
+
+    extension_type = 0x000D
+
+    def __init__(self, algorithms):
+        self.algorithms = algorithms
+
+    def encode(self):
+        algs_bytes = b"".join(struct.pack("!H", a) for a in self.algorithms)
+        return struct.pack("!H", len(algs_bytes)) + algs_bytes
+
+
+class ALPNExtension(Extension):
+    """Application-Layer Protocol Negotiation (ALPN) extension (type 0x0010).
+
+    Allows the client to indicate supported application protocols
+    (e.g., 'h2', 'http/1.1') during the TLS handshake.
+    """
+
+    extension_type = 0x0010
+
+    def __init__(self, protocols):
+        self.protocols = protocols
+
+    def encode(self):
+        protocols_data = b""
+        for protocol in self.protocols:
+            proto_bytes = protocol.encode('utf-8')
+            protocols_data += struct.pack("!B", len(proto_bytes)) + proto_bytes
+        return struct.pack("!H", len(protocols_data)) + protocols_data
+
+
+class ECPointFormatsExtension(Extension):
+    """EC Point Formats extension (type 0x000B).
+
+    Indicates the point formats the client can parse for elliptic curve points.
+
+    Format IDs: 0 = uncompressed, 1 = ansiX962_compressed_prime,
+                2 = ansiX962_compressed_char2
+    """
+
+    extension_type = 0x000B
+
+    def __init__(self, formats=None):
+        self.formats = formats or [0]  # uncompressed by default
+
+    def encode(self):
+        formats_bytes = b"".join(struct.pack("!B", f) for f in self.formats)
+        return struct.pack("!B", len(formats_bytes)) + formats_bytes
+
+
+class SessionTicketExtension(Extension):
+    """Session Ticket extension (type 0x0023).
+
+    Used for TLS session resumption without server-side state.
+    An empty extension indicates the client supports session tickets
+    but does not have one to offer.
+    """
+
+    extension_type = 0x0023
+
+    def __init__(self, ticket=None):
+        self.ticket = ticket or b""
+
+    def encode(self):
+        return self.ticket
+
+
+class ExtendedMasterSecretExtension(Extension):
+    """Extended Master Secret extension (type 0x0017).
+
+    Strengthens the TLS master secret computation to bind it to the
+    full handshake transcript, mitigating certain man-in-the-middle attacks.
+    (RFC 7627)
+    """
+
+    extension_type = 0x0017
+
+    def encode(self):
+        return b""
+
+
+class RenegotiationInfoExtension(Extension):
+    """Renegotiation Info extension (type 0xFF01).
+
+    Indicates support for secure renegotiation.
+    For initial handshakes, the renegotiated_connection field is empty.
+    (RFC 5746)
+    """
+
+    extension_type = 0xFF01
+
+    def __init__(self, renegotiated_connection=None):
+        self.renegotiated_connection = renegotiated_connection or b""
+
+    def encode(self):
+        return struct.pack("!B", len(self.renegotiated_connection)) + self.renegotiated_connection
+
+
+class StatusRequestExtension(Extension):
+    """Certificate Status Request (OCSP Stapling) extension (type 0x0005).
+
+    Requests the server to provide an OCSP response during the handshake
+    to prove its certificate has not been revoked. (RFC 6066)
+    """
+
+    extension_type = 0x0005
+
+    def encode(self):
+        # status_type = ocsp(1), responder_id_list = empty, request_extensions = empty
+        return struct.pack("!BHH", 1, 0, 0)

--- a/ja3requests/protocol/tls/layers/client_hello.py
+++ b/ja3requests/protocol/tls/layers/client_hello.py
@@ -2,33 +2,18 @@
 
 import struct
 from ja3requests.protocol.tls.layers import HandShake
+from ja3requests.protocol.tls.extensions import (
+    Extension,
+    SNIExtension,
+    SupportedGroupsExtension,
+    SignatureAlgorithmsExtension,
+    ALPNExtension,
+)
 
 
 class ClientHello(HandShake):
     """
     The ClientHello message includes a random structure, which is used later in the protocol.
-
-    opaque SessionID<0..32>;
-    uint8 CipherSuite[2];    /* Cryptographic suite selector */
-    enum { null(0), (255) } CompressionMethod;
-
-    struct {
-        ExtensionType extension_type;
-        opaque extension_data<0..2^16-1>;
-    } Extension;
-
-    enum {
-        signature_algorithms(13), (65535)
-    } ExtensionType;
-    -  "extension_type" identifies the particular extension type.
-    -  "extension_data" contains information specific to the particular extension type.
-
-    struct {
-        uint8 major;
-        uint8 minor;
-    } ProtocolVersion;
-
-    ProtocolVersion version = { 3, 3 };     /* TLS v1.2*/
 
     struct {
         ProtocolVersion client_version;
@@ -43,88 +28,6 @@ class ClientHello(HandShake):
                 Extension extensions<0..2^16-1>;
         };
     } ClientHello;
-
-    cipher_suites
-        This is a list of the cryptographic options supported by the
-        client, with the client's first preference first.  If the
-        session_id field is not empty (implying a session resumption
-        request), this vector MUST include at least the cipher_suite from
-        that session.
-
-        A cipher suite defines a cipher specification supported in TLS
-        Version 1.2.
-            CipherSuite TLS_NULL_WITH_NULL_NULL               = { 0x00,0x00 };
-
-        The following CipherSuite definitions require that the server provide
-        an RSA certificate that can be used for key exchange.  The server may
-        request any signature-capable certificate in the certificate request
-        message.
-            CipherSuite TLS_RSA_WITH_NULL_MD5                 = { 0x00,0x01 };
-            CipherSuite TLS_RSA_WITH_NULL_SHA                 = { 0x00,0x02 };
-            CipherSuite TLS_RSA_WITH_NULL_SHA256              = { 0x00,0x3B };
-            CipherSuite TLS_RSA_WITH_RC4_128_MD5              = { 0x00,0x04 };
-            CipherSuite TLS_RSA_WITH_RC4_128_SHA              = { 0x00,0x05 };
-            CipherSuite TLS_RSA_WITH_3DES_EDE_CBC_SHA         = { 0x00,0x0A };
-            CipherSuite TLS_RSA_WITH_AES_128_CBC_SHA          = { 0x00,0x2F };
-            CipherSuite TLS_RSA_WITH_AES_256_CBC_SHA          = { 0x00,0x35 };
-            CipherSuite TLS_RSA_WITH_AES_128_CBC_SHA256       = { 0x00,0x3C };
-            CipherSuite TLS_RSA_WITH_AES_256_CBC_SHA256       = { 0x00,0x3D };
-
-        The following cipher suite definitions are used for server-
-        authenticated (and optionally client-authenticated) Diffie-Hellman.
-        DH denotes cipher suites in which the server's certificate contains
-        the Diffie-Hellman parameters signed by the certificate authority
-        (CA).  DHE denotes ephemeral Diffie-Hellman, where the Diffie-Hellman
-        parameters are signed by a signature-capable certificate, which has
-        been signed by the CA.  The signing algorithm used by the server is
-        specified after the DHE component of the CipherSuite name.  The
-        server can request any signature-capable certificate from the client
-        for client authentication, or it may request a Diffie-Hellman
-        certificate.  Any Diffie-Hellman certificate provided by the client
-        must use the parameters (group and generator) described by the
-        server.
-            CipherSuite TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA      = { 0x00,0x0D };
-            CipherSuite TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA      = { 0x00,0x10 };
-            CipherSuite TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA     = { 0x00,0x13 };
-            CipherSuite TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA     = { 0x00,0x16 };
-            CipherSuite TLS_DH_DSS_WITH_AES_128_CBC_SHA       = { 0x00,0x30 };
-            CipherSuite TLS_DH_RSA_WITH_AES_128_CBC_SHA       = { 0x00,0x31 };
-            CipherSuite TLS_DHE_DSS_WITH_AES_128_CBC_SHA      = { 0x00,0x32 };
-            CipherSuite TLS_DHE_RSA_WITH_AES_128_CBC_SHA      = { 0x00,0x33 };
-            CipherSuite TLS_DH_DSS_WITH_AES_256_CBC_SHA       = { 0x00,0x36 };
-            CipherSuite TLS_DH_RSA_WITH_AES_256_CBC_SHA       = { 0x00,0x37 };
-            CipherSuite TLS_DHE_DSS_WITH_AES_256_CBC_SHA      = { 0x00,0x38 };
-            CipherSuite TLS_DHE_RSA_WITH_AES_256_CBC_SHA      = { 0x00,0x39 };
-            CipherSuite TLS_DH_DSS_WITH_AES_128_CBC_SHA256    = { 0x00,0x3E };
-            CipherSuite TLS_DH_RSA_WITH_AES_128_CBC_SHA256    = { 0x00,0x3F };
-            CipherSuite TLS_DHE_DSS_WITH_AES_128_CBC_SHA256   = { 0x00,0x40 };
-            CipherSuite TLS_DHE_RSA_WITH_AES_128_CBC_SHA256   = { 0x00,0x67 };
-            CipherSuite TLS_DH_DSS_WITH_AES_256_CBC_SHA256    = { 0x00,0x68 };
-            CipherSuite TLS_DH_RSA_WITH_AES_256_CBC_SHA256    = { 0x00,0x69 };
-            CipherSuite TLS_DHE_DSS_WITH_AES_256_CBC_SHA256   = { 0x00,0x6A };
-            CipherSuite TLS_DHE_RSA_WITH_AES_256_CBC_SHA256   = { 0x00,0x6B };
-
-        The following cipher suites are used for completely anonymous
-        Diffie-Hellman communications in which neither party is
-        authenticated.  Note that this mode is vulnerable to man-in-the-
-        middle attacks.  Using this mode therefore is of limited use: These
-        cipher suites MUST NOT be used by TLS 1.2 implementations unless the
-        application layer has specifically requested to allow anonymous key
-        exchange.  (Anonymous key exchange may sometimes be acceptable, for
-        example, to support opportunistic encryption when no set-up for
-        authentication is in place, or when TLS is used as part of more
-        complex security protocols that have other means to ensure
-        authentication.)
-            CipherSuite TLS_DH_anon_WITH_RC4_128_MD5          = { 0x00,0x18 };
-            CipherSuite TLS_DH_anon_WITH_3DES_EDE_CBC_SHA     = { 0x00,0x1B };
-            CipherSuite TLS_DH_anon_WITH_AES_128_CBC_SHA      = { 0x00,0x34 };
-            CipherSuite TLS_DH_anon_WITH_AES_256_CBC_SHA      = { 0x00,0x3A };
-            CipherSuite TLS_DH_anon_WITH_AES_128_CBC_SHA256   = { 0x00,0x6C };
-            CipherSuite TLS_DH_anon_WITH_AES_256_CBC_SHA256   = { 0x00,0x6D };
-
-        Note: The cipher suite values { 0x00, 0x1C } and { 0x00, 0x1D } are
-        reserved to avoid collision with Fortezza-based cipher suites in
-        SSL 3.
     """
 
     def __init__(
@@ -147,10 +50,11 @@ class ClientHello(HandShake):
         self._cipher_suites = None
         self._extensions = None
         self._server_name = server_name
-        self._supported_groups = supported_groups  # Don't set defaults
-        self._signature_algorithms = signature_algorithms  # Don't set defaults
+        self._supported_groups = supported_groups
+        self._signature_algorithms = signature_algorithms
         self._alpn_protocols = alpn_protocols or []
         self._use_grease = use_grease
+        self._custom_extensions = _extensions or []
 
         # Set cipher suites
         if cipher_suites:
@@ -183,7 +87,6 @@ class ClientHello(HandShake):
 
         if not self._version:
             self._version = struct.pack("B", 3) + struct.pack("B", 3)
-            # self._version = struct.pack("I", 771)[:2]
 
         return self._version
 
@@ -217,81 +120,42 @@ class ClientHello(HandShake):
 
     def _build_extensions(self):
         """
-        Build TLS extensions based on configuration
+        Build TLS extensions from Extension objects and configuration parameters.
+
+        Priority order:
+        1. Custom Extension objects passed via _extensions (from TlsConfig)
+        2. Extensions auto-generated from individual parameters (server_name, etc.)
+
+        If a custom extension has the same type as an auto-generated one,
+        the custom extension takes precedence.
         """
-        extensions = b""
+        extension_list = []
 
-        # Server Name Indication (SNI) - Extension Type 0
-        if self._server_name:
-            sni_data = self._build_sni_extension()
-            extensions += struct.pack("!H", 0)  # Extension type
-            extensions += struct.pack("!H", len(sni_data))  # Extension length
-            extensions += sni_data
+        # Collect custom Extension objects first
+        custom_types = set()
+        for ext in self._custom_extensions:
+            if isinstance(ext, Extension):
+                extension_list.append(ext)
+                custom_types.add(ext.extension_type)
 
-        # Supported Groups (Elliptic Curves) - Extension Type 10
-        if self._supported_groups and len(self._supported_groups) > 0:
-            groups_data = self._build_supported_groups_extension()
-            extensions += struct.pack("!H", 10)  # Extension type
-            extensions += struct.pack("!H", len(groups_data))  # Extension length
-            extensions += groups_data
+        # Auto-generate extensions from parameters (skip if custom one exists)
+        if self._server_name and SNIExtension.extension_type not in custom_types:
+            extension_list.append(SNIExtension(self._server_name))
 
-        # Signature Algorithms - Extension Type 13
-        if self._signature_algorithms and len(self._signature_algorithms) > 0:
-            sig_algs_data = self._build_signature_algorithms_extension()
-            extensions += struct.pack("!H", 13)  # Extension type
-            extensions += struct.pack("!H", len(sig_algs_data))  # Extension length
-            extensions += sig_algs_data
+        if (self._supported_groups and len(self._supported_groups) > 0
+                and SupportedGroupsExtension.extension_type not in custom_types):
+            extension_list.append(SupportedGroupsExtension(self._supported_groups))
 
-        # Application Layer Protocol Negotiation (ALPN) - Extension Type 16
-        if self._alpn_protocols:
-            alpn_data = self._build_alpn_extension()
-            extensions += struct.pack("!H", 16)  # Extension type
-            extensions += struct.pack("!H", len(alpn_data))  # Extension length
-            extensions += alpn_data
+        if (self._signature_algorithms and len(self._signature_algorithms) > 0
+                and SignatureAlgorithmsExtension.extension_type not in custom_types):
+            extension_list.append(SignatureAlgorithmsExtension(self._signature_algorithms))
 
-        # For compatibility, only include basic extensions
-        # Extended Master Secret and Session Ticket can cause issues with some servers
+        if self._alpn_protocols and ALPNExtension.extension_type not in custom_types:
+            extension_list.append(ALPNExtension(self._alpn_protocols))
 
-        if extensions:
-            # Add extensions length header
-            self._extensions = struct.pack("!H", len(extensions)) + extensions
-
-    def _build_sni_extension(self):
-        """Build Server Name Indication extension"""
-        server_name_bytes = self._server_name.encode('utf-8')
-        sni_data = struct.pack(
-            "!H", len(server_name_bytes) + 3
-        )  # Server name list length
-        sni_data += struct.pack("!B", 0)  # Name type (hostname)
-        sni_data += struct.pack("!H", len(server_name_bytes))  # Name length
-        sni_data += server_name_bytes
-        return sni_data
-
-    def _build_supported_groups_extension(self):
-        """Build Supported Groups extension"""
-        groups_data = struct.pack("!H", len(self._supported_groups) * 2)  # Length
-        for group in self._supported_groups:
-            groups_data += struct.pack("!H", group)
-        return groups_data
-
-    def _build_signature_algorithms_extension(self):
-        """Build Signature Algorithms extension"""
-        sig_data = struct.pack("!H", len(self._signature_algorithms) * 2)  # Length
-        for sig_alg in self._signature_algorithms:
-            sig_data += struct.pack("!H", sig_alg)
-        return sig_data
-
-    def _build_alpn_extension(self):
-        """Build Application Layer Protocol Negotiation extension"""
-        protocols_data = b""
-        for protocol in self._alpn_protocols:
-            protocol_bytes = protocol.encode('utf-8')
-            protocols_data += struct.pack("!B", len(protocol_bytes))
-            protocols_data += protocol_bytes
-
-        alpn_data = struct.pack("!H", len(protocols_data))  # Protocol list length
-        alpn_data += protocols_data
-        return alpn_data
+        if extension_list:
+            extensions_data = b"".join(ext.to_bytes() for ext in extension_list)
+            self._extensions = struct.pack("!H", len(extensions_data)) + extensions_data
 
 
 if __name__ == '__main__':

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -1,0 +1,291 @@
+"""Tests for ja3requests.protocol.tls.extensions module."""
+
+import struct
+import unittest
+
+from ja3requests.protocol.tls.extensions import (
+    Extension,
+    SNIExtension,
+    SupportedGroupsExtension,
+    SignatureAlgorithmsExtension,
+    ALPNExtension,
+    ECPointFormatsExtension,
+    SessionTicketExtension,
+    ExtendedMasterSecretExtension,
+    RenegotiationInfoExtension,
+    StatusRequestExtension,
+)
+
+
+class TestExtensionBase(unittest.TestCase):
+    """Test the Extension ABC."""
+
+    def test_cannot_instantiate_abc(self):
+        with self.assertRaises(TypeError):
+            Extension()
+
+    def test_to_bytes_includes_type_and_length(self):
+        ext = SNIExtension("example.com")
+        raw = ext.to_bytes()
+        ext_type, ext_len = struct.unpack("!HH", raw[:4])
+        self.assertEqual(ext_type, 0x0000)
+        self.assertEqual(ext_len, len(raw) - 4)
+
+    def test_repr(self):
+        ext = SNIExtension("example.com")
+        self.assertIn("SNIExtension", repr(ext))
+        self.assertIn("0x0000", repr(ext))
+
+
+class TestSNIExtension(unittest.TestCase):
+    """Test Server Name Indication extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(SNIExtension.extension_type, 0x0000)
+
+    def test_encode_structure(self):
+        ext = SNIExtension("example.com")
+        data = ext.encode()
+        # Should have: 2 bytes list length, 1 byte name type, 2 bytes name length, name
+        name = b"example.com"
+        expected_entry_len = 1 + 2 + len(name)  # type + name_len + name
+        list_len = struct.unpack("!H", data[:2])[0]
+        self.assertEqual(list_len, expected_entry_len)
+
+        name_type = data[2]
+        self.assertEqual(name_type, 0)  # hostname
+
+        name_len = struct.unpack("!H", data[3:5])[0]
+        self.assertEqual(name_len, len(name))
+
+        self.assertEqual(data[5:], name)
+
+    def test_to_bytes_roundtrip(self):
+        ext = SNIExtension("test.example.com")
+        raw = ext.to_bytes()
+        # First 2 bytes: type, next 2: length
+        self.assertEqual(struct.unpack("!H", raw[:2])[0], 0x0000)
+
+
+class TestSupportedGroupsExtension(unittest.TestCase):
+    """Test Supported Groups extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(SupportedGroupsExtension.extension_type, 0x000A)
+
+    def test_encode_single_group(self):
+        ext = SupportedGroupsExtension([23])
+        data = ext.encode()
+        # 2 bytes length + 2 bytes per group
+        groups_len = struct.unpack("!H", data[:2])[0]
+        self.assertEqual(groups_len, 2)
+        group = struct.unpack("!H", data[2:4])[0]
+        self.assertEqual(group, 23)
+
+    def test_encode_multiple_groups(self):
+        groups = [23, 24, 25, 29]
+        ext = SupportedGroupsExtension(groups)
+        data = ext.encode()
+        groups_len = struct.unpack("!H", data[:2])[0]
+        self.assertEqual(groups_len, len(groups) * 2)
+        for i, expected in enumerate(groups):
+            actual = struct.unpack("!H", data[2 + i * 2:4 + i * 2])[0]
+            self.assertEqual(actual, expected)
+
+
+class TestSignatureAlgorithmsExtension(unittest.TestCase):
+    """Test Signature Algorithms extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(SignatureAlgorithmsExtension.extension_type, 0x000D)
+
+    def test_encode(self):
+        algs = [0x0401, 0x0501, 0x0601]
+        ext = SignatureAlgorithmsExtension(algs)
+        data = ext.encode()
+        algs_len = struct.unpack("!H", data[:2])[0]
+        self.assertEqual(algs_len, len(algs) * 2)
+        for i, expected in enumerate(algs):
+            actual = struct.unpack("!H", data[2 + i * 2:4 + i * 2])[0]
+            self.assertEqual(actual, expected)
+
+
+class TestALPNExtension(unittest.TestCase):
+    """Test ALPN extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(ALPNExtension.extension_type, 0x0010)
+
+    def test_encode_single_protocol(self):
+        ext = ALPNExtension(["http/1.1"])
+        data = ext.encode()
+        # 2 bytes list length, then: 1 byte proto length + proto
+        list_len = struct.unpack("!H", data[:2])[0]
+        proto_len = data[2]
+        self.assertEqual(proto_len, len("http/1.1"))
+        proto = data[3:3 + proto_len].decode()
+        self.assertEqual(proto, "http/1.1")
+        self.assertEqual(list_len, 1 + proto_len)
+
+    def test_encode_multiple_protocols(self):
+        ext = ALPNExtension(["h2", "http/1.1"])
+        data = ext.encode()
+        list_len = struct.unpack("!H", data[:2])[0]
+        # h2: 1 + 2 = 3, http/1.1: 1 + 8 = 9 => total 12
+        self.assertEqual(list_len, 12)
+
+
+class TestECPointFormatsExtension(unittest.TestCase):
+    """Test EC Point Formats extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(ECPointFormatsExtension.extension_type, 0x000B)
+
+    def test_default_uncompressed(self):
+        ext = ECPointFormatsExtension()
+        data = ext.encode()
+        fmt_count = data[0]
+        self.assertEqual(fmt_count, 1)
+        self.assertEqual(data[1], 0)  # uncompressed
+
+    def test_custom_formats(self):
+        ext = ECPointFormatsExtension([0, 1, 2])
+        data = ext.encode()
+        self.assertEqual(data[0], 3)
+
+
+class TestSessionTicketExtension(unittest.TestCase):
+    """Test Session Ticket extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(SessionTicketExtension.extension_type, 0x0023)
+
+    def test_empty_ticket(self):
+        ext = SessionTicketExtension()
+        data = ext.encode()
+        self.assertEqual(data, b"")
+
+    def test_with_ticket(self):
+        ticket = b"\x01\x02\x03\x04"
+        ext = SessionTicketExtension(ticket)
+        self.assertEqual(ext.encode(), ticket)
+
+
+class TestExtendedMasterSecretExtension(unittest.TestCase):
+    """Test Extended Master Secret extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(ExtendedMasterSecretExtension.extension_type, 0x0017)
+
+    def test_empty_body(self):
+        ext = ExtendedMasterSecretExtension()
+        self.assertEqual(ext.encode(), b"")
+
+    def test_to_bytes_length_zero(self):
+        ext = ExtendedMasterSecretExtension()
+        raw = ext.to_bytes()
+        ext_type, ext_len = struct.unpack("!HH", raw[:4])
+        self.assertEqual(ext_type, 0x0017)
+        self.assertEqual(ext_len, 0)
+
+
+class TestRenegotiationInfoExtension(unittest.TestCase):
+    """Test Renegotiation Info extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(RenegotiationInfoExtension.extension_type, 0xFF01)
+
+    def test_initial_handshake(self):
+        ext = RenegotiationInfoExtension()
+        data = ext.encode()
+        # 1 byte length (0) for empty renegotiated_connection
+        self.assertEqual(data, b"\x00")
+
+
+class TestStatusRequestExtension(unittest.TestCase):
+    """Test Status Request (OCSP Stapling) extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(StatusRequestExtension.extension_type, 0x0005)
+
+    def test_encode(self):
+        ext = StatusRequestExtension()
+        data = ext.encode()
+        # status_type(1) + responder_id_list_len(0) + request_extensions_len(0)
+        self.assertEqual(len(data), 5)
+        status_type = data[0]
+        self.assertEqual(status_type, 1)  # ocsp
+
+
+class TestClientHelloWithExtensions(unittest.TestCase):
+    """Test that ClientHello correctly builds extensions from Extension objects."""
+
+    def test_custom_extension_in_client_hello(self):
+        from ja3requests.protocol.tls.layers.client_hello import ClientHello
+
+        ext = ExtendedMasterSecretExtension()
+        hello = ClientHello(
+            _extensions=[ext],
+        )
+        # Extensions should be present in the message
+        self.assertIsNotNone(hello.extensions)
+        # The extension bytes should contain type 0x0017
+        self.assertIn(struct.pack("!H", 0x0017), hello.extensions)
+
+    def test_custom_extension_overrides_auto(self):
+        """Custom SNI extension should override auto-generated one."""
+        from ja3requests.protocol.tls.layers.client_hello import ClientHello
+
+        custom_sni = SNIExtension("custom.example.com")
+        hello = ClientHello(
+            server_name="auto.example.com",
+            _extensions=[custom_sni],
+        )
+        # Should contain custom name, not auto
+        self.assertIn(b"custom.example.com", hello.extensions)
+        self.assertNotIn(b"auto.example.com", hello.extensions)
+
+    def test_mixed_custom_and_auto_extensions(self):
+        """Custom extensions and auto-generated ones should coexist."""
+        from ja3requests.protocol.tls.layers.client_hello import ClientHello
+
+        ems = ExtendedMasterSecretExtension()
+        hello = ClientHello(
+            server_name="example.com",
+            supported_groups=[23, 24],
+            _extensions=[ems],
+        )
+        ext_data = hello.extensions
+        # Should have SNI (auto), SupportedGroups (auto), and EMS (custom)
+        self.assertIn(struct.pack("!H", 0x0000), ext_data)  # SNI
+        self.assertIn(struct.pack("!H", 0x000A), ext_data)  # SupportedGroups
+        self.assertIn(struct.pack("!H", 0x0017), ext_data)  # EMS
+
+
+class TestTlsConfigWithExtensions(unittest.TestCase):
+    """Test TlsConfig extension integration."""
+
+    def test_add_extension_object(self):
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        config = TlsConfig()
+        ext = ECPointFormatsExtension()
+        config.add_extension(ext)
+        self.assertIn(ext, config.extensions)
+
+    def test_ja3_string_includes_extension_types(self):
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        config = TlsConfig()
+        config.server_name = "example.com"
+        config.add_extension(ExtendedMasterSecretExtension())
+        ja3 = config.get_ja3_string()
+        extensions_field = ja3.split(",")[2]
+        # Should include EMS type (0x0017 = 23) and SNI type (0x0000 = 0)
+        ext_types = extensions_field.split("-")
+        self.assertIn("23", ext_types)  # EMS
+        self.assertIn("0", ext_types)   # SNI
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -287,5 +287,29 @@ class TestTlsConfigWithExtensions(unittest.TestCase):
         self.assertIn("0", ext_types)   # SNI
 
 
+class TestJA3NoneEdgeCases(unittest.TestCase):
+    """Test get_ja3_string with None values that could crash."""
+
+    def test_ja3_with_none_supported_groups(self):
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        config = TlsConfig()
+        config.supported_groups = None
+        # Should not crash
+        ja3 = config.get_ja3_string()
+        parts = ja3.split(",")
+        self.assertEqual(len(parts), 5)
+        self.assertEqual(parts[3], "")  # empty elliptic curves
+
+    def test_ja3_with_empty_supported_groups(self):
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        config = TlsConfig()
+        config.supported_groups = []
+        ja3 = config.get_ja3_string()
+        parts = ja3.split(",")
+        self.assertEqual(parts[3], "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add 9 concrete `Extension` subclasses: SNI, SupportedGroups, SignatureAlgorithms, ALPN, ECPointFormats, SessionTicket, ExtendedMasterSecret, RenegotiationInfo, StatusRequest
- Refactor `ClientHello._build_extensions()` to use Extension objects instead of hardcoded raw byte packing
- Wire `TlsConfig._extensions` into handshake — custom extensions override auto-generated ones of same type
- Update `get_ja3_string()` to reflect actual extension types sent
- Guard against `None` supported_groups in JA3 string generation

## Test plan

- [x] 34 extension tests pass (encoding, wire format, ClientHello integration, JA3 generation)
- [x] All 27 existing TlsConfig tests pass (no regression)
- [x] Full test suite passes (191+ tests)

Closes #4

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL