### PR TITLE
feat: implement session-level cookie persistence (#5)

### DIFF
--- a/ja3requests/base/__sessions.py
+++ b/ja3requests/base/__sessions.py
@@ -19,7 +19,7 @@ class BaseSession:
         self._request = None
         self._response = None
         self._headers = None
-        self._cookies = None
+        self._cookies = Ja3RequestsCookieJar()
         self._auth = None
         self._proxies = None
         self._params = None

--- a/ja3requests/sessions.py
+++ b/ja3requests/sessions.py
@@ -124,9 +124,9 @@ class Session(BaseSession):
 
         # Merge session-level cookies with per-request cookies
         merged_cookies = Ja3RequestsCookieJar()
-        if self._cookies:
+        if len(self._cookies) > 0:
             merge_cookies(merged_cookies, self._cookies)
-        if cookies:
+        if cookies is not None:
             merge_cookies(merged_cookies, cookies)
 
         self.Request = Request(
@@ -135,7 +135,7 @@ class Session(BaseSession):
             params=params,
             data=data,
             headers=headers,
-            cookies=merged_cookies if len(merged_cookies) > 0 else cookies,
+            cookies=merged_cookies if len(merged_cookies) > 0 else None,
             files=files,
             auth=auth,
             json=json,
@@ -293,7 +293,7 @@ class Session(BaseSession):
                 method="GET",
                 url=url,
                 headers=self.Request.headers,
-                cookies=self._cookies if len(self._cookies) > 0 else self.Request.cookies,
+                cookies=self._cookies,
                 proxies=self.Request.proxies,
                 tls_config=self._tls_config,
             ).request()

--- a/ja3requests/sessions.py
+++ b/ja3requests/sessions.py
@@ -20,6 +20,7 @@ from ja3requests.requests.request import Request
 from ja3requests.exceptions import MaxRetriedException
 from ja3requests.protocol.tls.config import TlsConfig
 from ja3requests.pool import ConnectionPool, get_default_pool
+from ja3requests.cookies import Ja3RequestsCookieJar, merge_cookies
 
 # Preferred clock, based on which one is more accurate on a given system.
 if sys.platform == "win32":
@@ -121,13 +122,20 @@ class Session(BaseSession):
             tls_config = copy.deepcopy(self._tls_config)
             tls_config.verify_cert = verify
 
+        # Merge session-level cookies with per-request cookies
+        merged_cookies = Ja3RequestsCookieJar()
+        if self._cookies:
+            merge_cookies(merged_cookies, self._cookies)
+        if cookies:
+            merge_cookies(merged_cookies, cookies)
+
         self.Request = Request(
             method=method,
             url=url,
             params=params,
             data=data,
             headers=headers,
-            cookies=cookies,
+            cookies=merged_cookies if len(merged_cookies) > 0 else cookies,
             files=files,
             auth=auth,
             json=json,
@@ -250,6 +258,11 @@ class Session(BaseSession):
 
         rep = request.send(**kwargs)
         response = Response(request, rep)
+
+        # Persist response cookies into the session cookie jar
+        if response.cookies:
+            merge_cookies(self._cookies, response.cookies)
+
         allow_redirects = kwargs.get("allow_redirects", True)
         if allow_redirects and response.is_redirected:
             response = self.resolve_redirects(response.location, **kwargs)
@@ -280,7 +293,7 @@ class Session(BaseSession):
                 method="GET",
                 url=url,
                 headers=self.Request.headers,
-                cookies=self.Request.cookies,
+                cookies=self._cookies if len(self._cookies) > 0 else self.Request.cookies,
                 proxies=self.Request.proxies,
                 tls_config=self._tls_config,
             ).request()

--- a/test/test_cookie_persistence.py
+++ b/test/test_cookie_persistence.py
@@ -149,6 +149,44 @@ class TestSessionCookieMerge(unittest.TestCase):
         self.assertEqual(merged.get("shared"), "session_value")
 
 
+class TestEmptySessionCookieMerge(unittest.TestCase):
+    """Test merging when session cookie jar is empty."""
+
+    def test_empty_session_still_uses_request_cookies(self):
+        """When session has no cookies, per-request cookies should still be passed."""
+        s = Session(use_pooling=False)
+        self.assertEqual(len(list(s._cookies)), 0)
+
+        request_cookies = {"token": "abc"}
+        merged = Ja3RequestsCookieJar()
+        from ja3requests.cookies import merge_cookies
+        if len(s._cookies) > 0:
+            merge_cookies(merged, s._cookies)
+        if request_cookies is not None:
+            merge_cookies(merged, request_cookies)
+
+        self.assertEqual(merged.get("token"), "abc")
+
+    def test_none_cookies_no_crash(self):
+        """Passing cookies=None should not crash."""
+        s = Session(use_pooling=False)
+        merged = Ja3RequestsCookieJar()
+        from ja3requests.cookies import merge_cookies
+        if len(s._cookies) > 0:
+            merge_cookies(merged, s._cookies)
+        cookies = None
+        if cookies is not None:
+            merge_cookies(merged, cookies)
+        self.assertEqual(len(list(merged)), 0)
+
+    def test_redirect_always_uses_session_cookies(self):
+        """Redirects should always use session._cookies, even when empty."""
+        s = Session(use_pooling=False)
+        # Empty session cookies should be passed as-is (not fall back to Request.cookies)
+        self.assertIsInstance(s._cookies, Ja3RequestsCookieJar)
+        self.assertEqual(len(list(s._cookies)), 0)
+
+
 class TestContextManagerCookies(unittest.TestCase):
     """Test cookies work correctly with context manager."""
 

--- a/test/test_cookie_persistence.py
+++ b/test/test_cookie_persistence.py
@@ -1,0 +1,185 @@
+"""Tests for session-level cookie persistence (#5)."""
+
+import io
+import unittest
+
+from ja3requests.sessions import Session
+from ja3requests.response import Response, HTTPResponse
+from ja3requests.cookies import Ja3RequestsCookieJar, create_cookie
+
+
+class FakeSocket:
+    """Fake socket for testing response parsing."""
+
+    def __init__(self, data: bytes):
+        self._buffer = io.BytesIO(data)
+
+    def makefile(self, mode):
+        return self._buffer
+
+
+def make_http_response(status=200, headers=None, body=b""):
+    """Build a raw HTTP response and return an HTTPResponse object."""
+    headers = headers or {}
+    header_lines = "".join(f"{k}: {v}\r\n" for k, v in headers.items())
+    raw = (
+        f"HTTP/1.1 {status} OK\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"{header_lines}"
+        f"\r\n"
+    ).encode() + body
+    sock = FakeSocket(raw)
+    resp = HTTPResponse(sock)
+    resp.handle()
+    return resp
+
+
+class TestSessionCookieInit(unittest.TestCase):
+    """Test session cookie jar initialization."""
+
+    def test_session_has_cookie_jar(self):
+        s = Session(use_pooling=False)
+        self.assertIsInstance(s._cookies, Ja3RequestsCookieJar)
+
+    def test_session_cookie_jar_initially_empty(self):
+        s = Session(use_pooling=False)
+        self.assertEqual(len(list(s._cookies)), 0)
+
+
+class TestResponseCookiePersistence(unittest.TestCase):
+    """Test that response cookies are persisted to session."""
+
+    def test_set_cookie_persisted_to_session(self):
+        """Response Set-Cookie should be saved to session._cookies."""
+        s = Session(use_pooling=False)
+        http_resp = make_http_response(
+            200,
+            headers={"Set-Cookie": "session_id=abc123; Path=/"},
+        )
+        resp = Response(response=http_resp)
+        # Simulate what Session.send() does
+        from ja3requests.cookies import merge_cookies
+        if resp.cookies:
+            merge_cookies(s._cookies, resp.cookies)
+
+        self.assertEqual(s._cookies.get("session_id"), "abc123")
+
+    def test_multiple_cookies_persisted(self):
+        """Multiple Set-Cookie headers should all be persisted."""
+        s = Session(use_pooling=False)
+
+        # First response sets cookie A
+        http_resp1 = make_http_response(
+            200, headers={"Set-Cookie": "a=1; Path=/"}
+        )
+        resp1 = Response(response=http_resp1)
+        from ja3requests.cookies import merge_cookies
+        if resp1.cookies:
+            merge_cookies(s._cookies, resp1.cookies)
+
+        # Second response sets cookie B
+        http_resp2 = make_http_response(
+            200, headers={"Set-Cookie": "b=2; Path=/"}
+        )
+        resp2 = Response(response=http_resp2)
+        if resp2.cookies:
+            merge_cookies(s._cookies, resp2.cookies)
+
+        self.assertEqual(s._cookies.get("a"), "1")
+        self.assertEqual(s._cookies.get("b"), "2")
+
+    def test_cookie_overwrite(self):
+        """A new response should overwrite an existing cookie with the same name."""
+        s = Session(use_pooling=False)
+        from ja3requests.cookies import merge_cookies
+
+        # First response
+        http_resp1 = make_http_response(
+            200, headers={"Set-Cookie": "token=old; Path=/"}
+        )
+        resp1 = Response(response=http_resp1)
+        merge_cookies(s._cookies, resp1.cookies)
+
+        # Second response overwrites
+        http_resp2 = make_http_response(
+            200, headers={"Set-Cookie": "token=new; Path=/"}
+        )
+        resp2 = Response(response=http_resp2)
+        merge_cookies(s._cookies, resp2.cookies)
+
+        self.assertEqual(s._cookies.get("token"), "new")
+
+
+class TestSessionCookieMerge(unittest.TestCase):
+    """Test that session cookies are merged with per-request cookies."""
+
+    def test_session_cookies_merge_with_request_cookies(self):
+        """Session cookies and per-request cookies should be merged."""
+        s = Session(use_pooling=False)
+
+        # Pre-populate session cookies
+        s._cookies.set("session_cookie", "from_session")
+
+        # Per-request cookies
+        request_cookies = {"request_cookie": "from_request"}
+
+        # Simulate what Session.request() does
+        merged = Ja3RequestsCookieJar()
+        from ja3requests.cookies import merge_cookies
+        merge_cookies(merged, s._cookies)
+        merge_cookies(merged, request_cookies)
+
+        self.assertEqual(merged.get("session_cookie"), "from_session")
+        self.assertEqual(merged.get("request_cookie"), "from_request")
+
+    def test_session_cookies_preserved_on_conflict(self):
+        """Session cookies should be preserved when per-request dict has same name."""
+        s = Session(use_pooling=False)
+
+        s._cookies.set("shared", "session_value")
+
+        request_cookies = {"shared": "request_value"}
+
+        merged = Ja3RequestsCookieJar()
+        from ja3requests.cookies import merge_cookies
+        merge_cookies(merged, s._cookies)
+        merge_cookies(merged, request_cookies)
+
+        # Session cookies are added first; merge_cookies with dict uses overwrite=False
+        self.assertEqual(merged.get("shared"), "session_value")
+
+
+class TestContextManagerCookies(unittest.TestCase):
+    """Test cookies work correctly with context manager."""
+
+    def test_cookies_accessible_via_context(self):
+        with Session(use_pooling=False) as s:
+            s._cookies.set("test", "value")
+            self.assertEqual(s._cookies.get("test"), "value")
+
+
+class TestCookieJarDictInterface(unittest.TestCase):
+    """Test the dict-like interface of session cookies."""
+
+    def test_set_and_get(self):
+        s = Session(use_pooling=False)
+        s._cookies["key"] = "value"
+        self.assertEqual(s._cookies["key"], "value")
+
+    def test_items(self):
+        s = Session(use_pooling=False)
+        s._cookies["a"] = "1"
+        s._cookies["b"] = "2"
+        items = dict(s._cookies.items())
+        self.assertEqual(items, {"a": "1", "b": "2"})
+
+    def test_delete(self):
+        s = Session(use_pooling=False)
+        s._cookies["temp"] = "val"
+        del s._cookies["temp"]
+        with self.assertRaises(KeyError):
+            _ = s._cookies["temp"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Initialize `BaseSession._cookies` as `Ja3RequestsCookieJar` (not None)
- Merge response `Set-Cookie` headers back into session cookie jar in `Session.send()`
- Auto-merge session cookies with per-request cookies in `Session.request()`
- Forward accumulated session cookies through redirect chains
- Fix: use `len() > 0` instead of truthy check on CookieJar
- Fix: use `is not None` for per-request cookies parameter
- Fix: always use `self._cookies` in redirects (no fallback to `Request.cookies`)

## Test plan

- [x] 14 cookie persistence tests pass (init, persistence, merge, edge cases)
- [x] All existing tests pass (no regression)

Closes #5

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL