### PR TITLE
feat: add response text encoding auto-detection (#7)

### DIFF
--- a/ja3requests/response.py
+++ b/ja3requests/response.py
@@ -224,6 +224,7 @@ class Response(BaseResponse):
         self.request = request
         self.response = response
         self.body = self.response.read_body() if self.response else b""
+        self._encoding = None  # user override
 
     def __repr__(self):
         """
@@ -300,12 +301,42 @@ class Response(BaseResponse):
         return self.body
 
     @property
-    def text(self):
+    def encoding(self):
         """
-        Response Text
+        Response encoding, detected from Content-Type header charset.
+        Can be set manually to override auto-detection.
+        Falls back to 'utf-8' if no charset is found.
         :return:
         """
-        return self.content.decode("utf8")
+        if self._encoding is not None:
+            return self._encoding
+
+        content_type = self.headers.get("Content-Type") or self.headers.get("content-type", "")
+        if "charset=" in content_type.lower():
+            # Extract charset value from Content-Type header
+            for part in content_type.split(";"):
+                part = part.strip()
+                if part.lower().startswith("charset="):
+                    charset = part.split("=", 1)[1].strip().strip('"').strip("'")
+                    return charset
+
+        return "utf-8"
+
+    @encoding.setter
+    def encoding(self, value):
+        """
+        Override the auto-detected encoding.
+        :param value: encoding name (e.g., 'gbk', 'iso-8859-1')
+        """
+        self._encoding = value
+
+    @property
+    def text(self):
+        """
+        Response Text, decoded using the detected or overridden encoding.
+        :return:
+        """
+        return self.content.decode(self.encoding)
 
     def json(self):
         """

--- a/ja3requests/response.py
+++ b/ja3requests/response.py
@@ -312,13 +312,16 @@ class Response(BaseResponse):
             return self._encoding
 
         content_type = self.headers.get("Content-Type") or self.headers.get("content-type", "")
-        if "charset=" in content_type.lower():
+        if "charset" in content_type.lower():
             # Extract charset value from Content-Type header
             for part in content_type.split(";"):
+                # Normalize: strip whitespace, handle "charset = value" with spaces around =
                 part = part.strip()
-                if part.lower().startswith("charset="):
+                lower_part = part.lower().replace(" ", "")
+                if lower_part.startswith("charset="):
                     charset = part.split("=", 1)[1].strip().strip('"').strip("'")
-                    return charset
+                    if charset:  # Guard against empty "charset="
+                        return charset
 
         return "utf-8"
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -85,6 +85,37 @@ class TestEncodingDetection(unittest.TestCase):
         self.assertEqual(resp.encoding, "shift_jis")
 
 
+class TestEncodingEdgeCases(unittest.TestCase):
+    """Test charset parsing edge cases."""
+
+    def test_empty_charset_value_falls_back(self):
+        """charset= with no value should fall back to utf-8."""
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset="},
+            body=b"test",
+        )
+        self.assertEqual(resp.encoding, "utf-8")
+
+    def test_whitespace_around_equals(self):
+        """charset = gbk (spaces around =) should be parsed."""
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset = gbk"},
+            body="你好".encode("gbk"),
+        )
+        self.assertEqual(resp.encoding, "gbk")
+
+    def test_no_space_after_semicolon(self):
+        """text/html;charset=utf-8 (no space) should work."""
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html;charset=utf-8"},
+            body=b"test",
+        )
+        self.assertEqual(resp.encoding, "utf-8")
+
+
 class TestEncodingOverride(unittest.TestCase):
     """Test manual encoding override."""
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1,0 +1,148 @@
+"""Tests for response text encoding auto-detection (#7)."""
+
+import io
+import unittest
+
+from ja3requests.response import Response, HTTPResponse
+
+
+class FakeSocket:
+    def __init__(self, data: bytes):
+        self._buffer = io.BytesIO(data)
+
+    def makefile(self, mode):
+        return self._buffer
+
+
+def make_response(status=200, headers=None, body=b""):
+    headers = headers or {}
+    header_lines = "".join(f"{k}: {v}\r\n" for k, v in headers.items())
+    raw = (
+        f"HTTP/1.1 {status} OK\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"{header_lines}"
+        f"\r\n"
+    ).encode() + body
+    sock = FakeSocket(raw)
+    http_resp = HTTPResponse(sock)
+    http_resp.handle()
+    return Response(response=http_resp)
+
+
+class TestEncodingDetection(unittest.TestCase):
+    """Test charset detection from Content-Type header."""
+
+    def test_default_encoding_utf8(self):
+        resp = make_response(200, body=b"hello")
+        self.assertEqual(resp.encoding, "utf-8")
+
+    def test_detect_charset_from_content_type(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=gbk"},
+            body="你好".encode("gbk"),
+        )
+        self.assertEqual(resp.encoding, "gbk")
+
+    def test_detect_charset_iso8859(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=iso-8859-1"},
+            body="caf\xe9".encode("iso-8859-1"),
+        )
+        self.assertEqual(resp.encoding, "iso-8859-1")
+
+    def test_charset_case_insensitive(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; Charset=UTF-16"},
+            body=b"",
+        )
+        self.assertEqual(resp.encoding, "UTF-16")
+
+    def test_content_type_without_charset(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"key": "value"}',
+        )
+        self.assertEqual(resp.encoding, "utf-8")
+
+    def test_charset_with_quotes(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": 'text/html; charset="utf-8"'},
+            body=b"test",
+        )
+        self.assertEqual(resp.encoding, "utf-8")
+
+    def test_multiple_content_type_params(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=shift_jis; boundary=something"},
+            body="テスト".encode("shift_jis"),
+        )
+        self.assertEqual(resp.encoding, "shift_jis")
+
+
+class TestEncodingOverride(unittest.TestCase):
+    """Test manual encoding override."""
+
+    def test_set_encoding(self):
+        resp = make_response(200, body=b"test")
+        resp.encoding = "ascii"
+        self.assertEqual(resp.encoding, "ascii")
+
+    def test_override_beats_header(self):
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=gbk"},
+            body=b"test",
+        )
+        resp.encoding = "utf-8"
+        self.assertEqual(resp.encoding, "utf-8")
+
+
+class TestTextDecoding(unittest.TestCase):
+    """Test that .text uses the correct encoding."""
+
+    def test_text_with_utf8(self):
+        body = "你好世界".encode("utf-8")
+        resp = make_response(200, body=body)
+        self.assertEqual(resp.text, "你好世界")
+
+    def test_text_with_gbk(self):
+        body = "你好世界".encode("gbk")
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=gbk"},
+            body=body,
+        )
+        self.assertEqual(resp.text, "你好世界")
+
+    def test_text_with_iso8859(self):
+        body = "café".encode("iso-8859-1")
+        resp = make_response(
+            200,
+            headers={"Content-Type": "text/html; charset=iso-8859-1"},
+            body=body,
+        )
+        self.assertEqual(resp.text, "café")
+
+    def test_text_with_manual_override(self):
+        body = "hello".encode("ascii")
+        resp = make_response(200, body=body)
+        resp.encoding = "ascii"
+        self.assertEqual(resp.text, "hello")
+
+    def test_text_wrong_encoding_raises(self):
+        """Using wrong encoding should raise or produce garbled text."""
+        body = "你好".encode("gbk")
+        resp = make_response(200, body=body)
+        # Default utf-8 can't decode gbk bytes
+        with self.assertRaises(UnicodeDecodeError):
+            _ = resp.text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `Response.encoding` property that parses `charset` from `Content-Type` header
- Add `Response.encoding` setter for manual override
- Update `Response.text` to use detected/overridden encoding instead of hardcoded UTF-8
- Fix: empty `charset=` falls back to UTF-8 instead of returning `""`
- Fix: spaces around `=` (e.g., `charset = gbk`) now correctly parsed

## Test plan

- [x] 17 encoding tests pass (detection, override, decoding, edge cases)
- [x] All 23 existing response tests pass (no regression)

Closes #7

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL