### PR TITLE
feat: support separate connect and read timeouts (#10)

### DIFF
--- a/ja3requests/base/__contexts.py
+++ b/ja3requests/base/__contexts.py
@@ -385,7 +385,9 @@ class BaseContext(ABC):
     @property
     def timeout(self):
         """
-        Context property timeout
+        Context property timeout.
+        Can be a single float (used for both connect and read)
+        or a tuple (connect_timeout, read_timeout).
         :return:
         """
         return self._timeout
@@ -398,6 +400,20 @@ class BaseContext(ABC):
         :return:
         """
         self._timeout = attr
+
+    @property
+    def connect_timeout(self):
+        """Extract connect timeout from timeout setting."""
+        if isinstance(self._timeout, tuple):
+            return self._timeout[0]
+        return self._timeout
+
+    @property
+    def read_timeout(self):
+        """Extract read timeout from timeout setting."""
+        if isinstance(self._timeout, tuple):
+            return self._timeout[1] if len(self._timeout) > 1 else self._timeout[0]
+        return self._timeout
 
     @property
     def proxy(self):

--- a/ja3requests/base/__sockets.py
+++ b/ja3requests/base/__sockets.py
@@ -57,7 +57,7 @@ class BaseSocket(ABC):
                 create_connection,
                 socket.error,
                 (dest_address, port),
-                self.context.timeout,
+                self.context.connect_timeout,
                 self.context.source_address,
             )
         except SocketTimeout as err:

--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -186,7 +186,7 @@ class TLS:
                 time.sleep(0.3)
 
                 # Check for server's response with longer timeout
-                self.conn.settimeout(self._handshake_timeout or 5.0)
+                self.conn.settimeout(self._handshake_timeout if self._handshake_timeout is not None else 5.0)
 
                 # Try to properly handle server's Change Cipher Spec + Finished
                 success = self._wait_for_server_handshake_completion()
@@ -214,7 +214,7 @@ class TLS:
         max_timeout = 10
 
         # Set socket timeout for receiving
-        recv_timeout = min(self._handshake_timeout, 5.0) if self._handshake_timeout else 1.0
+        recv_timeout = min(self._handshake_timeout, 5.0) if self._handshake_timeout is not None else 1.0
         self.conn.settimeout(recv_timeout)
 
         while True:

--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -59,7 +59,7 @@ ECDHE_CIPHER_SUITES = frozenset(
 class TLS:
     """TLS 1.2 handshake handler with support for custom JA3 fingerprints."""
 
-    def __init__(self, conn):
+    def __init__(self, conn, handshake_timeout=None):
         self._tls_version = None
         self._body = None
         self.conn = conn
@@ -71,6 +71,7 @@ class TLS:
         self._supported_groups = None
         self._signature_algorithms = None
         self._cipher_suites = None
+        self._handshake_timeout = handshake_timeout
 
         # Sequence numbers for record layer encryption/decryption
         # These are reset to 0 after ChangeCipherSpec
@@ -185,7 +186,7 @@ class TLS:
                 time.sleep(0.3)
 
                 # Check for server's response with longer timeout
-                self.conn.settimeout(5.0)
+                self.conn.settimeout(self._handshake_timeout or 5.0)
 
                 # Try to properly handle server's Change Cipher Spec + Finished
                 success = self._wait_for_server_handshake_completion()
@@ -213,7 +214,8 @@ class TLS:
         max_timeout = 10
 
         # Set socket timeout for receiving
-        self.conn.settimeout(1.0)
+        recv_timeout = min(self._handshake_timeout, 5.0) if self._handshake_timeout else 1.0
+        self.conn.settimeout(recv_timeout)
 
         while True:
             try:

--- a/ja3requests/sockets/http.py
+++ b/ja3requests/sockets/http.py
@@ -44,6 +44,9 @@ class HttpSocket(BaseSocket):
         Connection send message
         :return:
         """
+        read_timeout = getattr(self.context, 'read_timeout', None)
+        if read_timeout is not None:
+            self.conn.settimeout(read_timeout)
         self.conn.sendall(self.context.message)
         return self.conn
 

--- a/ja3requests/sockets/https.py
+++ b/ja3requests/sockets/https.py
@@ -132,8 +132,8 @@ class HttpsSocket(BaseSocket):
         try:
             # Brief delay for server to process our Finished message
             time.sleep(0.3)
-            read_timeout = getattr(self.context, 'read_timeout', None) or 15.0
-            self.conn.settimeout(read_timeout)
+            read_timeout = getattr(self.context, 'read_timeout', None)
+            self.conn.settimeout(read_timeout if read_timeout is not None else 15.0)
 
             # Encrypt and send HTTP request
             encrypted_data = self._encrypt_application_data(self.context.message)

--- a/ja3requests/sockets/https.py
+++ b/ja3requests/sockets/https.py
@@ -56,7 +56,8 @@ class HttpsSocket(BaseSocket):
         self.conn = self._new_conn(host, port)
 
         # TLS handshake
-        tls = TLS(self.conn)
+        handshake_timeout = getattr(self.context, 'connect_timeout', None)
+        tls = TLS(self.conn, handshake_timeout=handshake_timeout)
 
         # Get TLS config and set default server_name
         tls_config = getattr(self.context, 'tls_config', None)
@@ -131,7 +132,8 @@ class HttpsSocket(BaseSocket):
         try:
             # Brief delay for server to process our Finished message
             time.sleep(0.3)
-            self.conn.settimeout(15.0)
+            read_timeout = getattr(self.context, 'read_timeout', None) or 15.0
+            self.conn.settimeout(read_timeout)
 
             # Encrypt and send HTTP request
             encrypted_data = self._encrypt_application_data(self.context.message)

--- a/test/test_timeout.py
+++ b/test/test_timeout.py
@@ -1,0 +1,163 @@
+"""Tests for timeout control improvement (#10)."""
+
+import unittest
+
+from ja3requests.sessions import Session
+from ja3requests.requests.request import Request
+
+
+class FakeContext:
+    """Minimal context for testing timeout properties."""
+
+    def __init__(self):
+        self._timeout = None
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, attr):
+        self._timeout = attr
+
+    @property
+    def connect_timeout(self):
+        if isinstance(self._timeout, tuple):
+            return self._timeout[0]
+        return self._timeout
+
+    @property
+    def read_timeout(self):
+        if isinstance(self._timeout, tuple):
+            return self._timeout[1] if len(self._timeout) > 1 else self._timeout[0]
+        return self._timeout
+
+
+class TestTimeoutTupleSupport(unittest.TestCase):
+    """Test that timeout can be a tuple (connect, read)."""
+
+    def test_single_float_timeout(self):
+        """Single float applies to both connect and read."""
+        from ja3requests.base.__contexts import BaseContext
+
+        class TestContext(BaseContext):
+            def set_payload(self, **kwargs):
+                pass
+
+        ctx = TestContext()
+        ctx.timeout = 10.0
+        self.assertEqual(ctx.connect_timeout, 10.0)
+        self.assertEqual(ctx.read_timeout, 10.0)
+
+    def test_tuple_timeout(self):
+        """Tuple separates connect and read timeouts."""
+        from ja3requests.base.__contexts import BaseContext
+
+        class TestContext(BaseContext):
+            def set_payload(self, **kwargs):
+                pass
+
+        ctx = TestContext()
+        ctx.timeout = (5.0, 30.0)
+        self.assertEqual(ctx.connect_timeout, 5.0)
+        self.assertEqual(ctx.read_timeout, 30.0)
+
+    def test_none_timeout(self):
+        """None timeout returns None for both."""
+        from ja3requests.base.__contexts import BaseContext
+
+        class TestContext(BaseContext):
+            def set_payload(self, **kwargs):
+                pass
+
+        ctx = TestContext()
+        ctx.timeout = None
+        self.assertIsNone(ctx.connect_timeout)
+        self.assertIsNone(ctx.read_timeout)
+
+
+class TestTimeoutPassthrough(unittest.TestCase):
+    """Test timeout flows through Session -> Request."""
+
+    def test_single_timeout_reaches_request(self):
+        req = Request(method="GET", url="http://example.com", timeout=10.0)
+        self.assertEqual(req.timeout, 10.0)
+
+    def test_tuple_timeout_reaches_request(self):
+        req = Request(method="GET", url="http://example.com", timeout=(5, 30))
+        self.assertEqual(req.timeout, (5, 30))
+
+    def test_session_request_signature_accepts_timeout(self):
+        """Session.request() accepts timeout parameter."""
+        import inspect
+        sig = inspect.signature(Session.request)
+        self.assertIn("timeout", sig.parameters)
+
+
+class TestTLSHandshakeTimeout(unittest.TestCase):
+    """Test TLS handshake uses configurable timeout."""
+
+    def test_tls_accepts_handshake_timeout(self):
+        """TLS constructor accepts handshake_timeout parameter."""
+        from ja3requests.protocol.tls import TLS
+        import socket
+
+        # Create a dummy socket pair for testing
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1, handshake_timeout=10.0)
+            self.assertEqual(tls._handshake_timeout, 10.0)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_tls_default_handshake_timeout_none(self):
+        """Default handshake timeout is None."""
+        from ja3requests.protocol.tls import TLS
+        import socket
+
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1)
+            self.assertIsNone(tls._handshake_timeout)
+        finally:
+            s1.close()
+            s2.close()
+
+
+class TestFakeContextTimeoutProperties(unittest.TestCase):
+    """Test the timeout property helpers directly."""
+
+    def test_single_value(self):
+        ctx = FakeContext()
+        ctx.timeout = 5.0
+        self.assertEqual(ctx.connect_timeout, 5.0)
+        self.assertEqual(ctx.read_timeout, 5.0)
+
+    def test_tuple_value(self):
+        ctx = FakeContext()
+        ctx.timeout = (3.0, 20.0)
+        self.assertEqual(ctx.connect_timeout, 3.0)
+        self.assertEqual(ctx.read_timeout, 20.0)
+
+    def test_single_element_tuple(self):
+        ctx = FakeContext()
+        ctx.timeout = (5.0,)
+        self.assertEqual(ctx.connect_timeout, 5.0)
+        self.assertEqual(ctx.read_timeout, 5.0)
+
+    def test_none_value(self):
+        ctx = FakeContext()
+        ctx.timeout = None
+        self.assertIsNone(ctx.connect_timeout)
+        self.assertIsNone(ctx.read_timeout)
+
+    def test_zero_timeout(self):
+        ctx = FakeContext()
+        ctx.timeout = 0
+        self.assertEqual(ctx.connect_timeout, 0)
+        self.assertEqual(ctx.read_timeout, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_timeout.py
+++ b/test/test_timeout.py
@@ -158,6 +158,37 @@ class TestFakeContextTimeoutProperties(unittest.TestCase):
         self.assertEqual(ctx.connect_timeout, 0)
         self.assertEqual(ctx.read_timeout, 0)
 
+    def test_tuple_with_zero_read(self):
+        """timeout=(5, 0) should give connect=5 and read=0, not fallback to 15."""
+        ctx = FakeContext()
+        ctx.timeout = (5.0, 0)
+        self.assertEqual(ctx.connect_timeout, 5.0)
+        self.assertEqual(ctx.read_timeout, 0)
+
+
+class TestReadTimeoutFallback(unittest.TestCase):
+    """Test that read_timeout=0 is not treated as falsy."""
+
+    def test_read_timeout_zero_not_replaced(self):
+        """read_timeout=0 must not be silently replaced with a default."""
+        # Simulates what HttpsSocket.send() does
+        read_timeout = 0
+        result = read_timeout if read_timeout is not None else 15.0
+        self.assertEqual(result, 0)
+
+    def test_read_timeout_none_gets_default(self):
+        """read_timeout=None should fall back to default 15.0."""
+        read_timeout = None
+        result = read_timeout if read_timeout is not None else 15.0
+        self.assertEqual(result, 15.0)
+
+    def test_handshake_timeout_zero_not_replaced(self):
+        """handshake_timeout=0 must not fall back to default."""
+        handshake_timeout = 0
+        # Simulates the TLS recv_timeout logic
+        result = min(handshake_timeout, 5.0) if handshake_timeout is not None else 1.0
+        self.assertEqual(result, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add `connect_timeout` and `read_timeout` properties to `BaseContext`
- Support `timeout` as tuple `(connect_timeout, read_timeout)` — single float applies to both
- Use `connect_timeout` in `BaseSocket._new_conn()` for TCP connect
- Use `read_timeout` in `HttpsSocket.send()` instead of hardcoded 15s
- Use `read_timeout` in `HttpSocket.send()` for HTTP response reading
- Add `handshake_timeout` parameter to `TLS` class for TLS handshake phase
- Fix: use `is not None` checks throughout to correctly handle `timeout=0`

## Test plan

- [x] 17 timeout tests pass (tuple/single/None/zero edge cases)
- [x] Full test suite passes (191+ tests, no regression)

Closes #10

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL