### PR TITLE
feat: add HTTP-level request retry with backoff (#11)

### DIFF
--- a/ja3requests/__init__.py
+++ b/ja3requests/__init__.py
@@ -8,6 +8,7 @@ Ja3Request
 from .sessions import Session
 from .protocol.tls.config import TlsConfig
 from .response import Response
+from .retry import HTTPRetry
 from .exceptions import (
     RequestException,
     HTTPError,

--- a/ja3requests/retry.py
+++ b/ja3requests/retry.py
@@ -1,0 +1,95 @@
+"""
+Ja3Requests.retry
+~~~~~~~~~~~~~~~~~
+
+HTTP-level retry with configurable backoff strategy.
+"""
+
+import time
+import random
+
+
+DEFAULT_STATUS_FORCELIST = frozenset({502, 503, 504})
+DEFAULT_ALLOWED_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "PUT", "DELETE"})
+DEFAULT_BACKOFF_FACTOR = 0.5
+DEFAULT_MAX_RETRIES = 3
+
+
+class HTTPRetry:
+    """
+    HTTP-level retry configuration with backoff.
+
+    Retries requests on:
+    - Configurable HTTP status codes (default: 502, 503, 504)
+    - Connection errors (ConnectionError, ConnectionResetError)
+
+    Supports exponential backoff with optional jitter.
+
+    Usage:
+        retry = HTTPRetry(total=3, backoff_factor=0.5)
+        session = Session(retry=retry)
+    """
+
+    def __init__(
+        self,
+        total=DEFAULT_MAX_RETRIES,
+        backoff_factor=DEFAULT_BACKOFF_FACTOR,
+        status_forcelist=None,
+        allowed_methods=None,
+        raise_on_status=True,
+        respect_retry_after=True,
+    ):
+        """
+        :param total: Maximum number of retries.
+        :param backoff_factor: Factor for exponential backoff.
+            Sleep time = backoff_factor * (2 ** (retry_number - 1))
+            e.g., 0.5 → 0.5s, 1s, 2s, 4s...
+        :param status_forcelist: Set of HTTP status codes to retry on.
+        :param allowed_methods: Set of HTTP methods that are safe to retry.
+        :param raise_on_status: If True, raise MaxRetriedException after all retries exhausted.
+        :param respect_retry_after: If True, honor Retry-After response header.
+        """
+        self.total = total
+        self.backoff_factor = backoff_factor
+        self.status_forcelist = status_forcelist or set(DEFAULT_STATUS_FORCELIST)
+        self.allowed_methods = allowed_methods or set(DEFAULT_ALLOWED_METHODS)
+        self.raise_on_status = raise_on_status
+        self.respect_retry_after = respect_retry_after
+
+    def is_retryable_method(self, method):
+        """Check if the HTTP method is safe to retry."""
+        return method.upper() in self.allowed_methods
+
+    def is_retryable_status(self, status_code):
+        """Check if the status code should trigger a retry."""
+        return status_code in self.status_forcelist
+
+    def get_backoff_time(self, retry_number):
+        """Calculate backoff time with jitter for a given retry attempt."""
+        if retry_number <= 0:
+            return 0
+        base = self.backoff_factor * (2 ** (retry_number - 1))
+        # Add jitter: random between 0 and base
+        return base + random.uniform(0, base * 0.1)
+
+    def get_retry_after(self, response):
+        """Parse Retry-After header value in seconds."""
+        if not self.respect_retry_after:
+            return None
+        retry_after = response.headers.get("Retry-After") or response.headers.get("retry-after")
+        if retry_after is None:
+            return None
+        try:
+            return float(retry_after)
+        except (ValueError, TypeError):
+            return None
+
+    def sleep_for_retry(self, response, retry_number):
+        """Sleep before retrying, respecting Retry-After if present."""
+        retry_after = self.get_retry_after(response) if response else None
+        if retry_after is not None:
+            time.sleep(retry_after)
+        else:
+            backoff = self.get_backoff_time(retry_number)
+            if backoff > 0:
+                time.sleep(backoff)

--- a/ja3requests/sessions.py
+++ b/ja3requests/sessions.py
@@ -21,6 +21,7 @@ from ja3requests.exceptions import MaxRetriedException
 from ja3requests.protocol.tls.config import TlsConfig
 from ja3requests.pool import ConnectionPool, get_default_pool
 from ja3requests.cookies import Ja3RequestsCookieJar, merge_cookies
+from ja3requests.retry import HTTPRetry
 
 # Preferred clock, based on which one is more accurate on a given system.
 if sys.platform == "win32":
@@ -41,6 +42,7 @@ class Session(BaseSession):
         pool: Optional[ConnectionPool] = None,
         use_pooling: bool = True,
         hooks: Dict = None,
+        retry: HTTPRetry = None,
     ):
         super().__init__()
         self._tls_config = tls_config or TlsConfig()
@@ -56,6 +58,7 @@ class Session(BaseSession):
             for event, callbacks in hooks.items():
                 if event in self.hooks:
                     self.hooks[event].extend(callbacks)
+        self._retry = retry
 
     @property
     def tls_config(self) -> TlsConfig:
@@ -272,7 +275,7 @@ class Session(BaseSession):
 
     def send(self, request: BaseRequest, **kwargs):
         """
-        Send request.
+        Send request with optional HTTP-level retry.
         :return:
         """
 
@@ -288,23 +291,67 @@ class Session(BaseSession):
         kwargs['pool'] = self._pool
 
         stream = kwargs.pop("stream", False)
-        rep = request.send(**kwargs)
-        response = Response(request, rep, stream=stream)
+        retry = self._retry
+        method = getattr(self.Request, 'method', 'GET') if self.Request else 'GET'
+        max_attempts = 1 + (retry.total if retry and retry.is_retryable_method(method) else 0)
 
-        # Persist response cookies into the session cookie jar
-        if response.cookies:
-            merge_cookies(self._cookies, response.cookies)
+        last_response = None
+        last_error = None
 
-        allow_redirects = kwargs.get("allow_redirects", True)
-        if allow_redirects and response.is_redirected:
-            response = self.resolve_redirects(response.location, **kwargs)
+        for attempt in range(max_attempts):
+            try:
+                rep = request.send(**kwargs)
+                response = Response(request, rep, stream=stream)
 
-        # Dispatch after_request hooks
-        response = self._dispatch_hooks("after_request", response, per_request_hooks)
+                # Persist response cookies into the session cookie jar
+                if response.cookies:
+                    merge_cookies(self._cookies, response.cookies)
 
-        self.response = response
+                # Check if we should retry based on status code
+                if (retry and attempt < max_attempts - 1
+                        and retry.is_retryable_method(method)
+                        and retry.is_retryable_status(response.status_code)):
+                    retry.sleep_for_retry(response, attempt + 1)
+                    last_response = response
+                    continue
 
-        return response
+                allow_redirects = kwargs.get("allow_redirects", True)
+                if allow_redirects and response.is_redirected:
+                    response = self.resolve_redirects(response.location, **kwargs)
+
+                # Dispatch after_request hooks
+                response = self._dispatch_hooks("after_request", response, per_request_hooks)
+
+                self.response = response
+                return response
+
+            except (ConnectionError, OSError) as err:
+                last_error = err
+                if retry and attempt < max_attempts - 1 and retry.is_retryable_method(method):
+                    retry.sleep_for_retry(None, attempt + 1)
+                    continue
+                raise
+
+        # All retries exhausted
+        if last_response is not None:
+            # Return the last response even if status was retryable
+            allow_redirects = kwargs.get("allow_redirects", True)
+            if allow_redirects and last_response.is_redirected:
+                last_response = self.resolve_redirects(last_response.location, **kwargs)
+            last_response = self._dispatch_hooks("after_request", last_response, per_request_hooks)
+            self.response = last_response
+            if retry and retry.raise_on_status:
+                raise MaxRetriedException(
+                    f"Max retries ({retry.total}) exceeded, last status: {last_response.status_code}"
+                )
+            return last_response
+
+        if last_error is not None:
+            raise MaxRetriedException(
+                f"Max retries ({retry.total}) exceeded"
+            ) from last_error
+
+        raise MaxRetriedException("Max retries exceeded")
 
     def resolve_redirects(self, url, **kwargs):
         """

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,0 +1,196 @@
+"""Tests for HTTP-level retry with backoff (#11)."""
+
+import unittest
+from unittest.mock import patch
+
+from ja3requests.retry import HTTPRetry
+
+
+class TestHTTPRetryDefaults(unittest.TestCase):
+    """Test HTTPRetry default configuration."""
+
+    def test_default_total(self):
+        retry = HTTPRetry()
+        self.assertEqual(retry.total, 3)
+
+    def test_default_backoff_factor(self):
+        retry = HTTPRetry()
+        self.assertEqual(retry.backoff_factor, 0.5)
+
+    def test_default_status_forcelist(self):
+        retry = HTTPRetry()
+        self.assertEqual(retry.status_forcelist, {502, 503, 504})
+
+    def test_default_allowed_methods(self):
+        retry = HTTPRetry()
+        self.assertIn("GET", retry.allowed_methods)
+        self.assertIn("HEAD", retry.allowed_methods)
+        self.assertNotIn("POST", retry.allowed_methods)
+
+    def test_default_raise_on_status(self):
+        retry = HTTPRetry()
+        self.assertTrue(retry.raise_on_status)
+
+
+class TestHTTPRetryCustom(unittest.TestCase):
+    """Test custom HTTPRetry configuration."""
+
+    def test_custom_total(self):
+        retry = HTTPRetry(total=5)
+        self.assertEqual(retry.total, 5)
+
+    def test_custom_status_forcelist(self):
+        retry = HTTPRetry(status_forcelist={500, 502})
+        self.assertIn(500, retry.status_forcelist)
+        self.assertNotIn(503, retry.status_forcelist)
+
+    def test_custom_allowed_methods(self):
+        retry = HTTPRetry(allowed_methods={"GET", "POST"})
+        self.assertIn("POST", retry.allowed_methods)
+
+    def test_custom_backoff_factor(self):
+        retry = HTTPRetry(backoff_factor=1.0)
+        self.assertEqual(retry.backoff_factor, 1.0)
+
+
+class TestRetryableChecks(unittest.TestCase):
+    """Test is_retryable_method and is_retryable_status."""
+
+    def test_get_is_retryable(self):
+        retry = HTTPRetry()
+        self.assertTrue(retry.is_retryable_method("GET"))
+
+    def test_post_not_retryable_by_default(self):
+        retry = HTTPRetry()
+        self.assertFalse(retry.is_retryable_method("POST"))
+
+    def test_case_insensitive_method(self):
+        retry = HTTPRetry()
+        self.assertTrue(retry.is_retryable_method("get"))
+
+    def test_502_is_retryable(self):
+        retry = HTTPRetry()
+        self.assertTrue(retry.is_retryable_status(502))
+
+    def test_200_not_retryable(self):
+        retry = HTTPRetry()
+        self.assertFalse(retry.is_retryable_status(200))
+
+    def test_500_not_retryable_by_default(self):
+        retry = HTTPRetry()
+        self.assertFalse(retry.is_retryable_status(500))
+
+
+class TestBackoffCalculation(unittest.TestCase):
+    """Test backoff time calculation."""
+
+    def test_zero_retry_no_backoff(self):
+        retry = HTTPRetry(backoff_factor=0.5)
+        self.assertEqual(retry.get_backoff_time(0), 0)
+
+    def test_first_retry_backoff(self):
+        retry = HTTPRetry(backoff_factor=0.5)
+        backoff = retry.get_backoff_time(1)
+        # 0.5 * 2^0 = 0.5, plus up to 10% jitter
+        self.assertGreaterEqual(backoff, 0.5)
+        self.assertLessEqual(backoff, 0.55 + 0.01)
+
+    def test_second_retry_backoff(self):
+        retry = HTTPRetry(backoff_factor=0.5)
+        backoff = retry.get_backoff_time(2)
+        # 0.5 * 2^1 = 1.0, plus up to 10% jitter
+        self.assertGreaterEqual(backoff, 1.0)
+        self.assertLessEqual(backoff, 1.1 + 0.01)
+
+    def test_third_retry_backoff(self):
+        retry = HTTPRetry(backoff_factor=0.5)
+        backoff = retry.get_backoff_time(3)
+        # 0.5 * 2^2 = 2.0, plus up to 10% jitter
+        self.assertGreaterEqual(backoff, 2.0)
+        self.assertLessEqual(backoff, 2.2 + 0.01)
+
+    def test_zero_backoff_factor(self):
+        retry = HTTPRetry(backoff_factor=0)
+        backoff = retry.get_backoff_time(1)
+        self.assertEqual(backoff, 0)
+
+
+class TestRetryAfter(unittest.TestCase):
+    """Test Retry-After header parsing."""
+
+    def test_retry_after_seconds(self):
+        retry = HTTPRetry()
+
+        class FakeResp:
+            headers = {"Retry-After": "5"}
+
+        self.assertEqual(retry.get_retry_after(FakeResp()), 5.0)
+
+    def test_retry_after_missing(self):
+        retry = HTTPRetry()
+
+        class FakeResp:
+            headers = {}
+
+        self.assertIsNone(retry.get_retry_after(FakeResp()))
+
+    def test_retry_after_disabled(self):
+        retry = HTTPRetry(respect_retry_after=False)
+
+        class FakeResp:
+            headers = {"Retry-After": "5"}
+
+        self.assertIsNone(retry.get_retry_after(FakeResp()))
+
+    def test_retry_after_invalid_value(self):
+        retry = HTTPRetry()
+
+        class FakeResp:
+            headers = {"Retry-After": "not-a-number"}
+
+        self.assertIsNone(retry.get_retry_after(FakeResp()))
+
+
+class TestSessionRetryIntegration(unittest.TestCase):
+    """Test Session integration with HTTPRetry."""
+
+    def test_session_accepts_retry(self):
+        from ja3requests.sessions import Session
+        retry = HTTPRetry(total=5)
+        s = Session(use_pooling=False, retry=retry)
+        self.assertIs(s._retry, retry)
+
+    def test_session_default_no_retry(self):
+        from ja3requests.sessions import Session
+        s = Session(use_pooling=False)
+        self.assertIsNone(s._retry)
+
+    def test_retry_exported(self):
+        import ja3requests
+        self.assertTrue(hasattr(ja3requests, "HTTPRetry"))
+
+
+class TestSleepForRetry(unittest.TestCase):
+    """Test sleep_for_retry behavior."""
+
+    @patch("ja3requests.retry.time.sleep")
+    def test_sleep_with_backoff(self, mock_sleep):
+        retry = HTTPRetry(backoff_factor=0.5)
+        retry.sleep_for_retry(None, 1)
+        mock_sleep.assert_called_once()
+        call_arg = mock_sleep.call_args[0][0]
+        self.assertGreaterEqual(call_arg, 0.5)
+
+    @patch("ja3requests.retry.time.sleep")
+    def test_sleep_with_retry_after(self, mock_sleep):
+        retry = HTTPRetry()
+
+        class FakeResp:
+            headers = {"Retry-After": "3"}
+
+        retry.sleep_for_retry(FakeResp(), 1)
+        mock_sleep.assert_called_once_with(3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `HTTPRetry` class with configurable retry strategy:
  - Retry on HTTP status codes (default: 502, 503, 504)
  - Retry on `ConnectionError` / `OSError`
  - Exponential backoff with jitter
  - Configurable allowed methods (default: GET, HEAD, OPTIONS, PUT, DELETE)
  - Respect `Retry-After` response header
- Integrate retry into `Session.send()` with max_attempts loop
- Add `retry` parameter to Session constructor
- Export `HTTPRetry` from `ja3requests` package

## Test plan

- [x] 29 retry tests pass (config, backoff, Retry-After, integration)
- [x] Full suite: 289 tests pass

Closes #11

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL