### PR TITLE
feat: add request/response event hooks system (#13)

### DIFF
--- a/ja3requests/sessions.py
+++ b/ja3requests/sessions.py
@@ -40,6 +40,7 @@ class Session(BaseSession):
         tls_config: TlsConfig = None,
         pool: Optional[ConnectionPool] = None,
         use_pooling: bool = True,
+        hooks: Dict = None,
     ):
         super().__init__()
         self._tls_config = tls_config or TlsConfig()
@@ -47,6 +48,14 @@ class Session(BaseSession):
         self._pool = (
             pool if pool is not None else (get_default_pool() if use_pooling else None)
         )
+        self.hooks = {
+            "before_request": [],
+            "after_request": [],
+        }
+        if hooks:
+            for event, callbacks in hooks.items():
+                if event in self.hooks:
+                    self.hooks[event].extend(callbacks)
 
     @property
     def tls_config(self) -> TlsConfig:
@@ -244,6 +253,23 @@ class Session(BaseSession):
 
         return self.request("DELETE", url, **kwargs)
 
+    def _dispatch_hooks(self, event, hook_data, per_request_hooks=None):
+        """
+        Call all registered hooks for a given event.
+        :param event: Hook event name (e.g., 'before_request', 'after_request')
+        :param hook_data: The object passed to each hook callback.
+        :param per_request_hooks: Optional per-request hooks dict.
+        :return: The hook_data (possibly modified by callbacks).
+        """
+        callbacks = list(self.hooks.get(event, []))
+        if per_request_hooks and event in per_request_hooks:
+            callbacks.extend(per_request_hooks[event])
+        for callback in callbacks:
+            result = callback(hook_data)
+            if result is not None:
+                hook_data = result
+        return hook_data
+
     def send(self, request: BaseRequest, **kwargs):
         """
         Send request.
@@ -252,6 +278,11 @@ class Session(BaseSession):
 
         if not isinstance(request, BaseRequest):
             raise ValueError("You can only send HttpRequest/HttpsRequest.")
+
+        per_request_hooks = kwargs.pop("hooks", None)
+
+        # Dispatch before_request hooks
+        request = self._dispatch_hooks("before_request", request, per_request_hooks)
 
         # Pass connection pool to request
         kwargs['pool'] = self._pool
@@ -266,6 +297,9 @@ class Session(BaseSession):
         allow_redirects = kwargs.get("allow_redirects", True)
         if allow_redirects and response.is_redirected:
             response = self.resolve_redirects(response.location, **kwargs)
+
+        # Dispatch after_request hooks
+        response = self._dispatch_hooks("after_request", response, per_request_hooks)
 
         self.response = response
 

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -1,0 +1,107 @@
+"""Tests for request/response event hooks (#13)."""
+
+import io
+import unittest
+
+from ja3requests.sessions import Session
+from ja3requests.response import Response, HTTPResponse
+
+
+class FakeSocket:
+    def __init__(self, data: bytes):
+        self._buffer = io.BytesIO(data)
+
+    def makefile(self, mode):
+        return self._buffer
+
+
+class TestHooksInit(unittest.TestCase):
+    """Test hooks initialization on Session."""
+
+    def test_default_hooks_dict(self):
+        s = Session(use_pooling=False)
+        self.assertIn("before_request", s.hooks)
+        self.assertIn("after_request", s.hooks)
+        self.assertEqual(s.hooks["before_request"], [])
+        self.assertEqual(s.hooks["after_request"], [])
+
+    def test_custom_hooks_on_init(self):
+        cb = lambda req: req
+        s = Session(use_pooling=False, hooks={"before_request": [cb]})
+        self.assertEqual(len(s.hooks["before_request"]), 1)
+        self.assertIs(s.hooks["before_request"][0], cb)
+
+    def test_unknown_hook_event_ignored(self):
+        s = Session(use_pooling=False, hooks={"unknown_event": [lambda x: x]})
+        self.assertNotIn("unknown_event", s.hooks)
+
+    def test_append_hook_after_init(self):
+        s = Session(use_pooling=False)
+        cb = lambda req: req
+        s.hooks["before_request"].append(cb)
+        self.assertEqual(len(s.hooks["before_request"]), 1)
+
+
+class TestHooksDispatch(unittest.TestCase):
+    """Test _dispatch_hooks helper."""
+
+    def test_dispatch_calls_all_callbacks(self):
+        s = Session(use_pooling=False)
+        call_log = []
+        s.hooks["after_request"].append(lambda r: call_log.append("cb1"))
+        s.hooks["after_request"].append(lambda r: call_log.append("cb2"))
+        s._dispatch_hooks("after_request", "data")
+        self.assertEqual(call_log, ["cb1", "cb2"])
+
+    def test_dispatch_returns_modified_data(self):
+        s = Session(use_pooling=False)
+        s.hooks["after_request"].append(lambda r: "modified")
+        result = s._dispatch_hooks("after_request", "original")
+        self.assertEqual(result, "modified")
+
+    def test_dispatch_chains_modifications(self):
+        s = Session(use_pooling=False)
+        s.hooks["after_request"].append(lambda r: r + "_a")
+        s.hooks["after_request"].append(lambda r: r + "_b")
+        result = s._dispatch_hooks("after_request", "start")
+        self.assertEqual(result, "start_a_b")
+
+    def test_dispatch_none_return_preserves_data(self):
+        s = Session(use_pooling=False)
+        s.hooks["after_request"].append(lambda r: None)  # returns None
+        result = s._dispatch_hooks("after_request", "preserved")
+        self.assertEqual(result, "preserved")
+
+    def test_dispatch_per_request_hooks(self):
+        s = Session(use_pooling=False)
+        call_log = []
+        s.hooks["after_request"].append(lambda r: call_log.append("session"))
+        per_req = {"after_request": [lambda r: call_log.append("request")]}
+        s._dispatch_hooks("after_request", "data", per_request_hooks=per_req)
+        self.assertEqual(call_log, ["session", "request"])
+
+    def test_dispatch_empty_event(self):
+        s = Session(use_pooling=False)
+        result = s._dispatch_hooks("after_request", "data")
+        self.assertEqual(result, "data")
+
+    def test_dispatch_nonexistent_event(self):
+        s = Session(use_pooling=False)
+        result = s._dispatch_hooks("nonexistent", "data")
+        self.assertEqual(result, "data")
+
+
+class TestHooksOrder(unittest.TestCase):
+    """Test that session-level hooks run before per-request hooks."""
+
+    def test_session_hooks_first(self):
+        s = Session(use_pooling=False)
+        order = []
+        s.hooks["before_request"].append(lambda r: order.append("session"))
+        per_req = {"before_request": [lambda r: order.append("per_request")]}
+        s._dispatch_hooks("before_request", "data", per_request_hooks=per_req)
+        self.assertEqual(order, ["session", "per_request"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `hooks` dict to Session with `before_request` and `after_request` events
- Session-level hooks persist across all requests
- Per-request hooks via `hooks` kwarg: `session.get(url, hooks={...})`
- Session hooks run before per-request hooks
- Callbacks can modify request/response by returning a new value; returning `None` preserves original

## Test plan

- [x] 12 hooks tests pass (init, dispatch, chaining, ordering)
- [x] Full suite: 272 tests pass

Closes #13

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL