### PR TITLE
feat: add SOCKS4/SOCKS5 proxy support (#12)

### DIFF
--- a/ja3requests/base/__contexts.py
+++ b/ja3requests/base/__contexts.py
@@ -415,18 +415,35 @@ class BaseContext(ABC):
             return self._timeout[1] if len(self._timeout) > 1 else self._timeout[0]
         return self._timeout
 
+    def _strip_proxy_scheme(self, value):
+        """Strip socks5://, socks4://, http:// scheme prefix from proxy value."""
+        if value and "://" in value:
+            return value.split("://", 1)[1]
+        return value
+
+    @property
+    def proxy_scheme(self):
+        """
+        Get the proxy scheme (socks5, socks4, http, or None).
+        :return:
+        """
+        if self._proxy and "://" in self._proxy:
+            return self._proxy.split("://", 1)[0].lower()
+        return None
+
     @property
     def proxy(self):
         """
-        Context property proxy
+        Context property proxy (host:port without scheme).
         :return:
         """
         proxy = None
         if self._proxy:
-            if "@" in self._proxy:
-                proxy = self._proxy.split("@")[-1]
+            raw = self._strip_proxy_scheme(self._proxy)
+            if "@" in raw:
+                proxy = raw.split("@")[-1]
             else:
-                proxy = self._proxy
+                proxy = raw
 
         return proxy
 
@@ -447,8 +464,9 @@ class BaseContext(ABC):
         """
         proxy_auth = None
         if self._proxy:
-            if "@" in self._proxy:
-                proxy_auth = self._proxy.split("@")[0]
+            raw = self._strip_proxy_scheme(self._proxy)
+            if "@" in raw:
+                proxy_auth = raw.split("@")[0]
 
         return proxy_auth
 

--- a/ja3requests/requests/http.py
+++ b/ja3requests/requests/http.py
@@ -9,6 +9,7 @@ from ja3requests.base import BaseRequest
 from ja3requests.contexts.context import HTTPContext
 from ja3requests.sockets.http import HttpSocket
 from ja3requests.sockets.proxy import ProxySocket
+from ja3requests.sockets.socks import SocksProxySocket
 from ja3requests.const import DEFAULT_HTTP_SCHEME, DEFAULT_HTTP_PORT
 from ja3requests.response import HTTPResponse
 
@@ -32,7 +33,12 @@ class HttpRequest(BaseRequest):
         :return:
         """
         if context.proxy:
-            sock = ProxySocket(context)
+            scheme = getattr(context, 'proxy_scheme', None)
+            if scheme in ('socks5', 'socks4'):
+                socks_ver = 5 if scheme == 'socks5' else 4
+                sock = SocksProxySocket(context, socks_version=socks_ver)
+            else:
+                sock = ProxySocket(context)
         else:
             sock = HttpSocket(context, pool=pool)
 

--- a/ja3requests/requests/https.py
+++ b/ja3requests/requests/https.py
@@ -10,6 +10,7 @@ from ja3requests.base import BaseRequest
 from ja3requests.contexts.context import HTTPSContext
 from ja3requests.sockets.https import HttpsSocket
 from ja3requests.sockets.proxy import ProxySocket
+from ja3requests.sockets.socks import SocksProxySocket
 from ja3requests.response import HTTPSResponse
 
 
@@ -32,7 +33,12 @@ class HttpsRequest(BaseRequest):
         :return:
         """
         if context.proxy:
-            sock = ProxySocket(context)
+            scheme = getattr(context, 'proxy_scheme', None)
+            if scheme in ('socks5', 'socks4'):
+                socks_ver = 5 if scheme == 'socks5' else 4
+                sock = SocksProxySocket(context, socks_version=socks_ver)
+            else:
+                sock = ProxySocket(context)
         else:
             sock = HttpsSocket(context, pool=pool)
 

--- a/ja3requests/requests/request.py
+++ b/ja3requests/requests/request.py
@@ -367,7 +367,9 @@ class Request:
 
     def __read_proxies(self):
         """
-        Read proxies
+        Read proxies.
+        Supports http, https, socks4, socks5 schemes.
+        Format: {'https': 'socks5://user:pass@host:port'} or {'https': 'host:port'}
         :return:
         """
         proxies = self.proxies
@@ -381,8 +383,9 @@ class Request:
                 "{'http': 'username:password@host:port', 'https': 'username:password@host:port'}"
             )
 
+        valid_keys = ("http", "https")
         for schema in proxies:
-            if schema not in ("http", "https"):
+            if schema not in valid_keys:
                 raise AttributeError(
                     f"Invalid proxy schema: {schema!r}.",
                     "The schema is only support http or https.",

--- a/ja3requests/sockets/socks.py
+++ b/ja3requests/sockets/socks.py
@@ -1,0 +1,245 @@
+"""
+Ja3Requests.sockets.socks
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SOCKS4/SOCKS5 proxy socket implementation.
+"""
+
+import struct
+import socket
+from ja3requests.base import BaseSocket
+from ja3requests.protocol.exceptions import (
+    SocketException,
+    ProxyError,
+    ProxyTimeoutError,
+)
+
+
+# SOCKS5 constants
+SOCKS5_VERSION = 0x05
+SOCKS5_AUTH_NONE = 0x00
+SOCKS5_AUTH_PASSWORD = 0x02
+SOCKS5_AUTH_NO_ACCEPTABLE = 0xFF
+SOCKS5_CMD_CONNECT = 0x01
+SOCKS5_ATYP_IPV4 = 0x01
+SOCKS5_ATYP_DOMAIN = 0x03
+SOCKS5_ATYP_IPV6 = 0x04
+SOCKS5_REPLY_SUCCESS = 0x00
+
+# SOCKS4 constants
+SOCKS4_VERSION = 0x04
+SOCKS4_CMD_CONNECT = 0x01
+SOCKS4_REPLY_GRANTED = 0x5A
+
+
+class SocksProxySocket(BaseSocket):
+    """
+    SOCKS4/SOCKS5 Proxy Socket.
+
+    Supports:
+    - SOCKS5 with no auth or username/password auth (RFC 1928, RFC 1929)
+    - SOCKS4/SOCKS4a with optional user ID
+    """
+
+    def __init__(self, context, socks_version=5):
+        super().__init__(context)
+        self.socks_version = socks_version
+
+        if self.context.proxy:
+            self.proxy_host, self.proxy_port = self.context.proxy.split(":")
+        else:
+            self.proxy_host, self.proxy_port = None, None
+
+        if self.context.proxy_auth:
+            if ":" in self.context.proxy_auth:
+                self.proxy_username, self.proxy_password = self.context.proxy_auth.split(":", 1)
+            else:
+                self.proxy_username, self.proxy_password = self.context.proxy_auth, None
+        else:
+            self.proxy_username, self.proxy_password = None, None
+
+    def new_conn(self):
+        if not self.proxy_host or not self.proxy_port:
+            raise SocketException("SOCKS proxy requires host and port.")
+
+        self.conn = self._new_conn(self.proxy_host, self.proxy_port)
+
+        try:
+            if self.socks_version == 5:
+                self._socks5_handshake()
+            elif self.socks_version == 4:
+                self._socks4_handshake()
+            else:
+                raise ProxyError(f"Unsupported SOCKS version: {self.socks_version}")
+        except (TimeoutError, ConnectionRefusedError, OSError) as err:
+            raise ProxyTimeoutError("SOCKS proxy connection failed") from err
+
+        return self
+
+    def _socks5_handshake(self):
+        """Perform SOCKS5 handshake (RFC 1928)."""
+        dest_host = self.context.destination_address
+        dest_port = self.context.port
+
+        # Step 1: Method selection
+        has_auth = self.proxy_username is not None
+        if has_auth:
+            # Offer both no-auth and username/password
+            self.conn.sendall(struct.pack("BBB", SOCKS5_VERSION, 2, SOCKS5_AUTH_NONE) +
+                              struct.pack("B", SOCKS5_AUTH_PASSWORD))
+        else:
+            self.conn.sendall(struct.pack("BBB", SOCKS5_VERSION, 1, SOCKS5_AUTH_NONE))
+
+        # Receive method selection response
+        resp = self._recv_exact_socks(2)
+        version, method = struct.unpack("BB", resp)
+
+        if version != SOCKS5_VERSION:
+            raise ProxyError(f"SOCKS5: unexpected version {version}")
+
+        if method == SOCKS5_AUTH_NO_ACCEPTABLE:
+            raise ProxyError("SOCKS5: no acceptable authentication method")
+
+        # Step 2: Authentication (if required)
+        if method == SOCKS5_AUTH_PASSWORD:
+            if not has_auth:
+                raise ProxyError("SOCKS5: server requires authentication but no credentials provided")
+            self._socks5_auth()
+        elif method != SOCKS5_AUTH_NONE:
+            raise ProxyError(f"SOCKS5: unsupported auth method {method}")
+
+        # Step 3: Connect request
+        # Use domain name (ATYP=0x03) to let proxy resolve DNS
+        dest_bytes = dest_host.encode("utf-8")
+        request = struct.pack("BBBB", SOCKS5_VERSION, SOCKS5_CMD_CONNECT, 0x00, SOCKS5_ATYP_DOMAIN)
+        request += struct.pack("B", len(dest_bytes)) + dest_bytes
+        request += struct.pack("!H", dest_port)
+        self.conn.sendall(request)
+
+        # Receive connect response
+        resp = self._recv_exact_socks(4)
+        version, reply, _, atyp = struct.unpack("BBBB", resp)
+
+        if reply != SOCKS5_REPLY_SUCCESS:
+            error_messages = {
+                0x01: "general SOCKS server failure",
+                0x02: "connection not allowed by ruleset",
+                0x03: "network unreachable",
+                0x04: "host unreachable",
+                0x05: "connection refused",
+                0x06: "TTL expired",
+                0x07: "command not supported",
+                0x08: "address type not supported",
+            }
+            msg = error_messages.get(reply, f"unknown error (0x{reply:02X})")
+            raise ProxyError(f"SOCKS5 connect failed: {msg}")
+
+        # Read and discard bound address
+        if atyp == SOCKS5_ATYP_IPV4:
+            self._recv_exact_socks(4 + 2)  # 4 bytes IP + 2 bytes port
+        elif atyp == SOCKS5_ATYP_DOMAIN:
+            addr_len = struct.unpack("B", self._recv_exact_socks(1))[0]
+            self._recv_exact_socks(addr_len + 2)  # domain + port
+        elif atyp == SOCKS5_ATYP_IPV6:
+            self._recv_exact_socks(16 + 2)  # 16 bytes IP + 2 bytes port
+
+    def _socks5_auth(self):
+        """SOCKS5 username/password authentication (RFC 1929)."""
+        username = self.proxy_username.encode("utf-8")
+        password = (self.proxy_password or "").encode("utf-8")
+
+        auth_request = struct.pack("BB", 0x01, len(username)) + username
+        auth_request += struct.pack("B", len(password)) + password
+        self.conn.sendall(auth_request)
+
+        resp = self._recv_exact_socks(2)
+        version, status = struct.unpack("BB", resp)
+        if status != 0x00:
+            raise ProxyError("SOCKS5 authentication failed")
+
+    def _socks4_handshake(self):
+        """Perform SOCKS4/SOCKS4a handshake."""
+        dest_host = self.context.destination_address
+        dest_port = self.context.port
+
+        user_id = (self.proxy_username or "").encode("utf-8")
+
+        # Try to resolve as IP for SOCKS4, fall back to SOCKS4a
+        try:
+            addr = socket.inet_aton(dest_host)
+            # SOCKS4: real IP
+            request = struct.pack("!BBH", SOCKS4_VERSION, SOCKS4_CMD_CONNECT, dest_port)
+            request += addr
+            request += user_id + b"\x00"
+        except OSError:
+            # SOCKS4a: use 0.0.0.x IP and append hostname
+            request = struct.pack("!BBH", SOCKS4_VERSION, SOCKS4_CMD_CONNECT, dest_port)
+            request += b"\x00\x00\x00\x01"  # invalid IP signals SOCKS4a
+            request += user_id + b"\x00"
+            request += dest_host.encode("utf-8") + b"\x00"
+
+        self.conn.sendall(request)
+
+        # Receive response (8 bytes)
+        resp = self._recv_exact_socks(8)
+        _, status = struct.unpack("!BH", resp[:3])
+        # Note: SOCKS4 reply version byte is 0x00, status at byte 1
+        status = resp[1]
+
+        if status != SOCKS4_REPLY_GRANTED:
+            error_messages = {
+                0x5B: "request rejected or failed",
+                0x5C: "cannot connect to identd on the client",
+                0x5D: "client identd reports different user-id",
+            }
+            msg = error_messages.get(status, f"unknown error (0x{status:02X})")
+            raise ProxyError(f"SOCKS4 connect failed: {msg}")
+
+    def _recv_exact_socks(self, n):
+        """Read exactly n bytes from the SOCKS proxy connection."""
+        data = b""
+        while len(data) < n:
+            chunk = self.conn.recv(n - len(data))
+            if not chunk:
+                raise ProxyError("SOCKS proxy closed connection unexpectedly")
+            data += chunk
+        return data
+
+    def send(self):
+        """
+        Send data through the established SOCKS tunnel.
+        :return:
+        """
+        # For HTTPS through SOCKS, TLS handshake happens after SOCKS connect
+        if hasattr(self.context, 'tls_config') and self.context.tls_config:
+            return self._send_https_through_socks()
+
+        # For HTTP through SOCKS, send directly
+        self.conn.sendall(self.context.message)
+        return self.conn
+
+    def _send_https_through_socks(self):
+        """Perform TLS handshake through the SOCKS tunnel."""
+        from ja3requests.sockets.https import HttpsSocket  # pylint: disable=import-outside-toplevel
+        from ja3requests.protocol.tls import TLS  # pylint: disable=import-outside-toplevel
+
+        tls = TLS(self.conn)
+        tls_config = self.context.tls_config
+        if tls_config and not getattr(tls_config, 'server_name', None):
+            tls_config.server_name = self.context.destination_address
+
+        tls.set_payload(tls_config=tls_config)
+        if not tls.handshake():
+            self.conn.close()
+            raise ConnectionError("TLS handshake failed through SOCKS tunnel")
+
+        # Create an HttpsSocket wrapper to handle encrypted send
+        class SocksTLSSocket(HttpsSocket):
+            """HttpsSocket that uses an existing SOCKS tunnel connection."""
+            def __init__(self, context, conn, tls_ctx):
+                super().__init__(context)
+                self.conn = conn
+                self.tls = tls_ctx
+
+        sock = SocksTLSSocket(self.context, self.conn, tls)
+        return sock.send()

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -1,0 +1,327 @@
+"""Tests for SOCKS4/SOCKS5 proxy support (#12)."""
+
+import struct
+import socket
+import unittest
+
+from ja3requests.sockets.socks import (
+    SocksProxySocket,
+    SOCKS5_VERSION,
+    SOCKS5_AUTH_NONE,
+    SOCKS5_AUTH_PASSWORD,
+    SOCKS5_REPLY_SUCCESS,
+    SOCKS4_VERSION,
+    SOCKS4_CMD_CONNECT,
+    SOCKS4_REPLY_GRANTED,
+)
+from ja3requests.protocol.exceptions import ProxyError
+
+
+class TestProxySchemeDetection(unittest.TestCase):
+    """Test proxy_scheme property on context."""
+
+    def _make_context(self, proxy_value):
+        from ja3requests.base.__contexts import BaseContext
+
+        class TestContext(BaseContext):
+            def set_payload(self, **kwargs):
+                pass
+
+        ctx = TestContext()
+        ctx._proxy = proxy_value
+        return ctx
+
+    def test_socks5_scheme(self):
+        ctx = self._make_context("socks5://127.0.0.1:1080")
+        self.assertEqual(ctx.proxy_scheme, "socks5")
+
+    def test_socks4_scheme(self):
+        ctx = self._make_context("socks4://127.0.0.1:1080")
+        self.assertEqual(ctx.proxy_scheme, "socks4")
+
+    def test_http_scheme(self):
+        ctx = self._make_context("http://127.0.0.1:8080")
+        self.assertEqual(ctx.proxy_scheme, "http")
+
+    def test_no_scheme(self):
+        ctx = self._make_context("127.0.0.1:8080")
+        self.assertIsNone(ctx.proxy_scheme)
+
+    def test_none_proxy(self):
+        ctx = self._make_context(None)
+        self.assertIsNone(ctx.proxy_scheme)
+
+
+class TestProxyHostParsing(unittest.TestCase):
+    """Test proxy host/port parsing with scheme URLs."""
+
+    def _make_context(self, proxy_value):
+        from ja3requests.base.__contexts import BaseContext
+
+        class TestContext(BaseContext):
+            def set_payload(self, **kwargs):
+                pass
+
+        ctx = TestContext()
+        ctx._proxy = proxy_value
+        return ctx
+
+    def test_socks5_host_port(self):
+        ctx = self._make_context("socks5://127.0.0.1:1080")
+        self.assertEqual(ctx.proxy, "127.0.0.1:1080")
+
+    def test_socks5_with_auth(self):
+        ctx = self._make_context("socks5://user:pass@127.0.0.1:1080")
+        self.assertEqual(ctx.proxy, "127.0.0.1:1080")
+        self.assertEqual(ctx.proxy_auth, "user:pass")
+
+    def test_plain_proxy_unchanged(self):
+        ctx = self._make_context("127.0.0.1:8080")
+        self.assertEqual(ctx.proxy, "127.0.0.1:8080")
+
+    def test_plain_proxy_with_auth(self):
+        ctx = self._make_context("user:pass@127.0.0.1:8080")
+        self.assertEqual(ctx.proxy, "127.0.0.1:8080")
+        self.assertEqual(ctx.proxy_auth, "user:pass")
+
+
+class TestSOCKS5Handshake(unittest.TestCase):
+    """Test SOCKS5 protocol messages (unit-level with socket pairs)."""
+
+    def test_socks5_no_auth_connect(self):
+        """SOCKS5 no-auth handshake produces correct wire format."""
+        s_client, s_server = socket.socketpair()
+        try:
+            from ja3requests.base.__contexts import BaseContext
+
+            class TestContext(BaseContext):
+                def set_payload(self, **kwargs):
+                    pass
+
+            ctx = TestContext()
+            ctx._proxy = "127.0.0.1:1080"
+            ctx._destination_address = "example.com"
+            ctx._port = 443
+
+            sock = SocksProxySocket(ctx, socks_version=5)
+            sock.conn = s_client
+
+            # Server side: respond to method selection
+            import threading
+
+            def server_side():
+                # Read method selection
+                data = s_server.recv(16)
+                self.assertEqual(data[0], SOCKS5_VERSION)  # version
+                # Respond: no auth required
+                s_server.sendall(struct.pack("BB", SOCKS5_VERSION, SOCKS5_AUTH_NONE))
+
+                # Read connect request
+                data = s_server.recv(256)
+                self.assertEqual(data[0], SOCKS5_VERSION)  # version
+                self.assertEqual(data[1], 0x01)  # CONNECT
+                self.assertEqual(data[3], 0x03)  # DOMAIN
+
+                # Respond: success with bound addr
+                resp = struct.pack("BBBB", SOCKS5_VERSION, SOCKS5_REPLY_SUCCESS, 0x00, 0x01)
+                resp += b"\x00\x00\x00\x00"  # bound addr (0.0.0.0)
+                resp += struct.pack("!H", 0)  # bound port
+                s_server.sendall(resp)
+
+            t = threading.Thread(target=server_side)
+            t.start()
+
+            sock._socks5_handshake()
+            t.join(timeout=2)
+
+        finally:
+            s_client.close()
+            s_server.close()
+
+    def test_socks5_auth_connect(self):
+        """SOCKS5 username/password auth produces correct wire format."""
+        s_client, s_server = socket.socketpair()
+        try:
+            from ja3requests.base.__contexts import BaseContext
+
+            class TestContext(BaseContext):
+                def set_payload(self, **kwargs):
+                    pass
+
+            ctx = TestContext()
+            ctx._proxy = "socks5://testuser:testpass@127.0.0.1:1080"
+            ctx._destination_address = "example.com"
+            ctx._port = 80
+
+            sock = SocksProxySocket(ctx, socks_version=5)
+            sock.conn = s_client
+
+            import threading
+
+            def server_side():
+                # Method selection
+                s_server.recv(16)
+                s_server.sendall(struct.pack("BB", SOCKS5_VERSION, SOCKS5_AUTH_PASSWORD))
+
+                # Auth
+                auth_data = s_server.recv(256)
+                self.assertEqual(auth_data[0], 0x01)  # auth version
+                ulen = auth_data[1]
+                username = auth_data[2:2 + ulen].decode()
+                self.assertEqual(username, "testuser")
+                # Respond: auth success
+                s_server.sendall(struct.pack("BB", 0x01, 0x00))
+
+                # Connect request
+                s_server.recv(256)
+                resp = struct.pack("BBBB", SOCKS5_VERSION, SOCKS5_REPLY_SUCCESS, 0x00, 0x01)
+                resp += b"\x00\x00\x00\x00" + struct.pack("!H", 0)
+                s_server.sendall(resp)
+
+            t = threading.Thread(target=server_side)
+            t.start()
+
+            sock._socks5_handshake()
+            t.join(timeout=2)
+
+        finally:
+            s_client.close()
+            s_server.close()
+
+    def test_socks5_connect_refused(self):
+        """SOCKS5 connection refused error."""
+        s_client, s_server = socket.socketpair()
+        try:
+            from ja3requests.base.__contexts import BaseContext
+
+            class TestContext(BaseContext):
+                def set_payload(self, **kwargs):
+                    pass
+
+            ctx = TestContext()
+            ctx._proxy = "127.0.0.1:1080"
+            ctx._destination_address = "example.com"
+            ctx._port = 443
+
+            sock = SocksProxySocket(ctx, socks_version=5)
+            sock.conn = s_client
+
+            import threading
+
+            def server_side():
+                s_server.recv(16)
+                s_server.sendall(struct.pack("BB", SOCKS5_VERSION, SOCKS5_AUTH_NONE))
+                s_server.recv(256)
+                # Reply: connection refused (0x05)
+                resp = struct.pack("BBBB", SOCKS5_VERSION, 0x05, 0x00, 0x01)
+                resp += b"\x00\x00\x00\x00" + struct.pack("!H", 0)
+                s_server.sendall(resp)
+
+            t = threading.Thread(target=server_side)
+            t.start()
+
+            with self.assertRaises(ProxyError) as cm:
+                sock._socks5_handshake()
+            self.assertIn("connection refused", str(cm.exception))
+            t.join(timeout=2)
+
+        finally:
+            s_client.close()
+            s_server.close()
+
+
+class TestSOCKS4Handshake(unittest.TestCase):
+    """Test SOCKS4/4a protocol messages."""
+
+    def test_socks4a_connect(self):
+        """SOCKS4a handshake with hostname."""
+        s_client, s_server = socket.socketpair()
+        try:
+            from ja3requests.base.__contexts import BaseContext
+
+            class TestContext(BaseContext):
+                def set_payload(self, **kwargs):
+                    pass
+
+            ctx = TestContext()
+            ctx._proxy = "127.0.0.1:1080"
+            ctx._destination_address = "example.com"
+            ctx._port = 80
+
+            sock = SocksProxySocket(ctx, socks_version=4)
+            sock.conn = s_client
+
+            import threading
+
+            def server_side():
+                data = s_server.recv(256)
+                self.assertEqual(data[0], SOCKS4_VERSION)
+                self.assertEqual(data[1], SOCKS4_CMD_CONNECT)
+                # Reply: granted
+                resp = struct.pack("!BBH", 0x00, SOCKS4_REPLY_GRANTED, 0)
+                resp += b"\x00\x00\x00\x00"
+                s_server.sendall(resp)
+
+            t = threading.Thread(target=server_side)
+            t.start()
+
+            sock._socks4_handshake()
+            t.join(timeout=2)
+
+        finally:
+            s_client.close()
+            s_server.close()
+
+    def test_socks4_rejected(self):
+        """SOCKS4 request rejected."""
+        s_client, s_server = socket.socketpair()
+        try:
+            from ja3requests.base.__contexts import BaseContext
+
+            class TestContext(BaseContext):
+                def set_payload(self, **kwargs):
+                    pass
+
+            ctx = TestContext()
+            ctx._proxy = "127.0.0.1:1080"
+            ctx._destination_address = "example.com"
+            ctx._port = 80
+
+            sock = SocksProxySocket(ctx, socks_version=4)
+            sock.conn = s_client
+
+            import threading
+
+            def server_side():
+                s_server.recv(256)
+                resp = struct.pack("!BBH", 0x00, 0x5B, 0)  # rejected
+                resp += b"\x00\x00\x00\x00"
+                s_server.sendall(resp)
+
+            t = threading.Thread(target=server_side)
+            t.start()
+
+            with self.assertRaises(ProxyError) as cm:
+                sock._socks4_handshake()
+            self.assertIn("rejected", str(cm.exception))
+            t.join(timeout=2)
+
+        finally:
+            s_client.close()
+            s_server.close()
+
+
+class TestRequestRouting(unittest.TestCase):
+    """Test that SOCKS proxy is routed correctly in request classes."""
+
+    def test_https_request_imports_socks(self):
+        from ja3requests.requests.https import SocksProxySocket as Imported
+        self.assertIs(Imported, SocksProxySocket)
+
+    def test_http_request_imports_socks(self):
+        from ja3requests.requests.http import SocksProxySocket as Imported
+        self.assertIs(Imported, SocksProxySocket)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `SocksProxySocket` with SOCKS5 (RFC 1928) and SOCKS4/4a support
- SOCKS5: no-auth and username/password auth (RFC 1929)
- SOCKS4a: hostname resolution by proxy server
- Add `proxy_scheme` property to `BaseContext` for `socks5://`/`socks4://` detection
- Strip scheme prefix in proxy host/auth parsing
- Route to `SocksProxySocket` in `HttpRequest` and `HttpsRequest`
- HTTPS-over-SOCKS: TLS handshake through established tunnel

## Test plan

- [x] 16 SOCKS tests pass (scheme detection, host parsing, SOCKS5/4 handshakes, routing)
- [x] Full suite: 336 tests pass

Closes #12

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL