### PR TITLE
feat: add TLS 1.3 foundation — HKDF, key schedule, extensions, record layer (#6)

### DIFF
--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-lines
 """TLS handshake implementation with JA3 fingerprint customization.
 
-This module provides a custom TLS 1.2 handshake implementation that supports
+This module provides a custom TLS 1.2/1.3 handshake implementation that supports
 both RSA and ECDHE key exchange, allowing JA3 fingerprint configuration.
 """
 import hashlib
@@ -76,6 +76,9 @@ class TLS:
         self._server_host = server_host
         self._server_port = server_port
         self._server_session_id = None  # session ID from ServerHello
+        self._is_tls13 = False
+        self._tls13_private_key = None
+        self._tls13_key_share_group = None
 
         # Sequence numbers for record layer encryption/decryption
         # These are reset to 0 after ChangeCipherSpec
@@ -148,8 +151,21 @@ class TLS:
                 self._verify_cert = False  # Default to False for backward compatibility
 
             # Update client hello with new configuration
+            # For TLS 1.3, record layer version stays 0x0303 for compatibility
+            client_hello_version = self.tls_version
+            is_tls13 = (tls_config.tls_version == 0x0304 if isinstance(tls_config.tls_version, int)
+                        else self.tls_version == b'\x03\x04')
+            if is_tls13:
+                # TLS 1.3: ClientHello version must be 0x0303 (TLS 1.2) for compatibility
+                client_hello_version = b'\x03\x03'
+
+            # Merge TLS 1.3 extensions into custom extensions
+            extensions = list(getattr(tls_config, 'extensions', None) or [])
+            if is_tls13:
+                self._setup_tls13_extensions(extensions, tls_config)
+
             self._body = ClientHello(
-                self.tls_version,
+                client_hello_version,
                 cipher_suites=self._cipher_suites,
                 client_random=self._client_random,
                 server_name=self._server_name,
@@ -157,8 +173,10 @@ class TLS:
                 signature_algorithms=self._signature_algorithms,
                 alpn_protocols=getattr(tls_config, 'alpn_protocols', None),
                 use_grease=getattr(tls_config, 'use_grease', True),
-                _extensions=getattr(tls_config, 'extensions', None),
+                _extensions=extensions,
             )
+
+            self._is_tls13 = is_tls13
 
             # Set cached session ID for resumption
             if self._session_cache is not None and self._server_host:
@@ -215,6 +233,33 @@ class TLS:
         except Exception as e:  # pylint: disable=broad-exception-caught
             debug(f"TLS Handshake failed: {e}")
             return False
+
+    def _setup_tls13_extensions(self, extensions, tls_config):
+        """Add TLS 1.3-specific extensions and generate key_share."""
+        from ja3requests.protocol.tls.extensions import (  # pylint: disable=import-outside-toplevel
+            SupportedVersionsExtension,
+            KeyShareExtension,
+            PSKKeyExchangeModesExtension,
+        )
+        from ja3requests.protocol.tls.tls13 import TLS13KeyExchange  # pylint: disable=import-outside-toplevel
+
+        existing_types = {ext.extension_type for ext in extensions if hasattr(ext, 'extension_type')}
+
+        # supported_versions: advertise TLS 1.3 + 1.2
+        if SupportedVersionsExtension.extension_type not in existing_types:
+            extensions.append(SupportedVersionsExtension([0x0304, 0x0303]))
+
+        # key_share: generate ECDHE key pair and include public key
+        if KeyShareExtension.extension_type not in existing_types:
+            # Default to x25519 (most widely supported for TLS 1.3)
+            private_key, public_bytes = TLS13KeyExchange.generate_x25519_keypair()
+            self._tls13_private_key = private_key
+            self._tls13_key_share_group = 0x001D  # x25519
+            extensions.append(KeyShareExtension([(0x001D, public_bytes)]))
+
+        # psk_key_exchange_modes (required even without PSK for some servers)
+        if PSKKeyExchangeModesExtension.extension_type not in existing_types:
+            extensions.append(PSKKeyExchangeModesExtension([1]))  # psk_dhe_ke
 
     def _save_session_to_cache(self):
         """Save the current session to the session cache for future resumption."""

--- a/ja3requests/protocol/tls/extensions/__init__.py
+++ b/ja3requests/protocol/tls/extensions/__init__.py
@@ -204,3 +204,68 @@ class StatusRequestExtension(Extension):
     def encode(self):
         # status_type = ocsp(1), responder_id_list = empty, request_extensions = empty
         return struct.pack("!BHH", 1, 0, 0)
+
+
+class SupportedVersionsExtension(Extension):
+    """Supported Versions extension (type 0x002B).
+
+    Required for TLS 1.3. Indicates which TLS versions the client supports.
+    In TLS 1.3, the client_version field in ClientHello is set to 0x0303 (TLS 1.2)
+    for compatibility, and the actual supported versions are listed here.
+    (RFC 8446 Section 4.2.1)
+    """
+
+    extension_type = 0x002B
+
+    def __init__(self, versions=None):
+        # Default: support TLS 1.3 and TLS 1.2
+        self.versions = versions or [0x0304, 0x0303]
+
+    def encode(self):
+        versions_bytes = b"".join(struct.pack("!H", v) for v in self.versions)
+        return struct.pack("B", len(versions_bytes)) + versions_bytes
+
+
+class KeyShareExtension(Extension):
+    """Key Share extension (type 0x0033).
+
+    Carries the client's ECDHE public key(s) in the ClientHello,
+    enabling 1-RTT handshake in TLS 1.3.
+    (RFC 8446 Section 4.2.8)
+
+    Named group IDs: 0x001D = x25519, 0x0017 = secp256r1
+    """
+
+    extension_type = 0x0033
+
+    def __init__(self, key_shares=None):
+        """
+        :param key_shares: List of (group_id, public_key_bytes) tuples.
+        """
+        self.key_shares = key_shares or []
+
+    def encode(self):
+        entries = b""
+        for group_id, key_bytes in self.key_shares:
+            entries += struct.pack("!HH", group_id, len(key_bytes)) + key_bytes
+        return struct.pack("!H", len(entries)) + entries
+
+
+class PSKKeyExchangeModesExtension(Extension):
+    """PSK Key Exchange Modes extension (type 0x002D).
+
+    Required when offering PSK. Indicates which PSK key exchange modes
+    the client supports.
+    (RFC 8446 Section 4.2.9)
+
+    Modes: 0 = psk_ke, 1 = psk_dhe_ke
+    """
+
+    extension_type = 0x002D
+
+    def __init__(self, modes=None):
+        self.modes = modes or [1]  # psk_dhe_ke by default
+
+    def encode(self):
+        modes_bytes = b"".join(struct.pack("B", m) for m in self.modes)
+        return struct.pack("B", len(modes_bytes)) + modes_bytes

--- a/ja3requests/protocol/tls/tls13.py
+++ b/ja3requests/protocol/tls/tls13.py
@@ -1,0 +1,324 @@
+"""
+ja3requests.protocol.tls.tls13
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TLS 1.3 (RFC 8446) implementation: HKDF key schedule, handshake, and record layer.
+"""
+
+import hashlib
+import hmac
+import os
+import struct
+
+from cryptography.hazmat.primitives.asymmetric import x25519, ec
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.backends import default_backend
+
+from ja3requests.protocol.tls.debug import debug
+
+
+# ============================================================================
+# HKDF Key Schedule (RFC 5869 + TLS 1.3 RFC 8446 Section 7.1)
+# ============================================================================
+
+class HKDF:
+    """HKDF (HMAC-based Key Derivation Function) for TLS 1.3."""
+
+    @staticmethod
+    def extract(salt, ikm, hash_algo=hashlib.sha256):
+        """
+        HKDF-Extract: extract a pseudorandom key from input keying material.
+
+        :param salt: Optional salt (if None, uses zero-filled bytes)
+        :param ikm: Input keying material
+        :param hash_algo: Hash algorithm (default: SHA-256)
+        :return: Pseudorandom key (PRK)
+        """
+        if salt is None:
+            salt = b"\x00" * hash_algo().digest_size
+        return hmac.new(salt, ikm, hash_algo).digest()
+
+    @staticmethod
+    def expand(prk, info, length, hash_algo=hashlib.sha256):
+        """
+        HKDF-Expand: expand a PRK into output keying material.
+
+        :param prk: Pseudorandom key from HKDF-Extract
+        :param info: Context/application-specific info
+        :param length: Output length in bytes
+        :param hash_algo: Hash algorithm
+        :return: Output keying material
+        """
+        hash_len = hash_algo().digest_size
+        n = (length + hash_len - 1) // hash_len
+        okm = b""
+        t = b""
+
+        for i in range(1, n + 1):
+            t = hmac.new(prk, t + info + struct.pack("B", i), hash_algo).digest()
+            okm += t
+
+        return okm[:length]
+
+    @staticmethod
+    def expand_label(prk, label, context, length, hash_algo=hashlib.sha256):
+        """
+        HKDF-Expand-Label for TLS 1.3 (RFC 8446 Section 7.1).
+
+        HkdfLabel = struct {
+            uint16 length;
+            opaque label<7..255> = "tls13 " + Label;
+            opaque context<0..255> = Context;
+        };
+
+        :param prk: Secret
+        :param label: Label string (without "tls13 " prefix)
+        :param context: Context bytes (usually transcript hash)
+        :param length: Desired output length
+        :return: Derived key material
+        """
+        tls_label = b"tls13 " + label.encode() if isinstance(label, str) else b"tls13 " + label
+        hkdf_label = struct.pack("!H", length)
+        hkdf_label += struct.pack("B", len(tls_label)) + tls_label
+        hkdf_label += struct.pack("B", len(context)) + context
+        return HKDF.expand(prk, hkdf_label, length, hash_algo)
+
+    @staticmethod
+    def derive_secret(secret, label, messages, hash_algo=hashlib.sha256):
+        """
+        Derive-Secret for TLS 1.3.
+
+        Derive-Secret(Secret, Label, Messages) =
+            HKDF-Expand-Label(Secret, Label, Transcript-Hash(Messages), Hash.length)
+
+        :param secret: The current secret
+        :param label: Label string
+        :param messages: Concatenated handshake messages (or b"" for empty)
+        :param hash_algo: Hash algorithm
+        :return: Derived secret
+        """
+        transcript_hash = hash_algo(messages).digest()
+        return HKDF.expand_label(secret, label, transcript_hash, hash_algo().digest_size, hash_algo)
+
+
+# ============================================================================
+# TLS 1.3 Key Schedule (RFC 8446 Section 7.1)
+# ============================================================================
+
+class TLS13KeySchedule:
+    """
+    TLS 1.3 Key Schedule.
+
+    Implements the full key derivation chain:
+        Early Secret → Handshake Secret → Master Secret
+    And derives traffic keys for each phase.
+    """
+
+    def __init__(self, hash_algo=hashlib.sha256):
+        self.hash_algo = hash_algo
+        self.hash_len = hash_algo().digest_size
+
+        # Secrets at each stage
+        self.early_secret = None
+        self.handshake_secret = None
+        self.master_secret = None
+
+        # Traffic secrets
+        self.client_handshake_traffic_secret = None
+        self.server_handshake_traffic_secret = None
+        self.client_application_traffic_secret = None
+        self.server_application_traffic_secret = None
+
+    def compute_early_secret(self, psk=None):
+        """
+        Compute Early Secret.
+
+        Early Secret = HKDF-Extract(salt=0, IKM=PSK or 0)
+        """
+        ikm = psk or (b"\x00" * self.hash_len)
+        self.early_secret = HKDF.extract(None, ikm, self.hash_algo)
+        debug(f"TLS 1.3 Early Secret: {self.early_secret.hex()[:32]}...")
+        return self.early_secret
+
+    def compute_handshake_secret(self, shared_secret, hello_messages=b""):
+        """
+        Compute Handshake Secret.
+
+        derived = Derive-Secret(early_secret, "derived", "")
+        Handshake Secret = HKDF-Extract(salt=derived, IKM=shared_secret)
+        """
+        if self.early_secret is None:
+            self.compute_early_secret()
+
+        derived = HKDF.derive_secret(self.early_secret, "derived", b"", self.hash_algo)
+        self.handshake_secret = HKDF.extract(derived, shared_secret, self.hash_algo)
+        debug(f"TLS 1.3 Handshake Secret: {self.handshake_secret.hex()[:32]}...")
+
+        # Derive handshake traffic secrets
+        self.client_handshake_traffic_secret = HKDF.derive_secret(
+            self.handshake_secret, "c hs traffic", hello_messages, self.hash_algo
+        )
+        self.server_handshake_traffic_secret = HKDF.derive_secret(
+            self.handshake_secret, "s hs traffic", hello_messages, self.hash_algo
+        )
+
+        return self.handshake_secret
+
+    def compute_master_secret(self, handshake_messages=b""):
+        """
+        Compute Master Secret.
+
+        derived = Derive-Secret(handshake_secret, "derived", "")
+        Master Secret = HKDF-Extract(salt=derived, IKM=0)
+        """
+        derived = HKDF.derive_secret(self.handshake_secret, "derived", b"", self.hash_algo)
+        self.master_secret = HKDF.extract(derived, b"\x00" * self.hash_len, self.hash_algo)
+        debug(f"TLS 1.3 Master Secret: {self.master_secret.hex()[:32]}...")
+
+        # Derive application traffic secrets
+        self.client_application_traffic_secret = HKDF.derive_secret(
+            self.master_secret, "c ap traffic", handshake_messages, self.hash_algo
+        )
+        self.server_application_traffic_secret = HKDF.derive_secret(
+            self.master_secret, "s ap traffic", handshake_messages, self.hash_algo
+        )
+
+        return self.master_secret
+
+    def derive_traffic_keys(self, secret, key_length=16, iv_length=12):
+        """
+        Derive traffic key and IV from a traffic secret.
+
+        key = HKDF-Expand-Label(Secret, "key", "", key_length)
+        iv  = HKDF-Expand-Label(Secret, "iv", "", iv_length)
+        """
+        key = HKDF.expand_label(secret, "key", b"", key_length, self.hash_algo)
+        iv = HKDF.expand_label(secret, "iv", b"", iv_length, self.hash_algo)
+        return key, iv
+
+    def compute_finished_key(self, base_key):
+        """
+        Derive Finished key from a handshake traffic secret.
+
+        finished_key = HKDF-Expand-Label(BaseKey, "finished", "", Hash.length)
+        """
+        return HKDF.expand_label(base_key, "finished", b"", self.hash_len, self.hash_algo)
+
+    def compute_finished_verify_data(self, finished_key, handshake_context):
+        """
+        Compute Finished verify_data.
+
+        verify_data = HMAC(finished_key, Transcript-Hash(handshake_context))
+        """
+        transcript_hash = self.hash_algo(handshake_context).digest()
+        return hmac.new(finished_key, transcript_hash, self.hash_algo).digest()
+
+
+# ============================================================================
+# TLS 1.3 ECDHE Key Exchange
+# ============================================================================
+
+class TLS13KeyExchange:
+    """TLS 1.3 ECDHE key exchange for key_share extension."""
+
+    @staticmethod
+    def generate_x25519_keypair():
+        """Generate X25519 private/public key pair."""
+        private_key = x25519.X25519PrivateKey.generate()
+        public_key = private_key.public_key()
+        public_bytes = public_key.public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        return private_key, public_bytes
+
+    @staticmethod
+    def generate_secp256r1_keypair():
+        """Generate secp256r1 (P-256) key pair."""
+        private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        public_key = private_key.public_key()
+        public_bytes = public_key.public_bytes(
+            serialization.Encoding.X962,
+            serialization.PublicFormat.UncompressedPoint,
+        )
+        return private_key, public_bytes
+
+    @staticmethod
+    def compute_x25519_shared_secret(private_key, peer_public_bytes):
+        """Compute shared secret from X25519 key exchange."""
+        peer_public = x25519.X25519PublicKey.from_public_bytes(peer_public_bytes)
+        return private_key.exchange(peer_public)
+
+    @staticmethod
+    def compute_secp256r1_shared_secret(private_key, peer_public_bytes):
+        """Compute shared secret from secp256r1 key exchange."""
+        peer_public = ec.EllipticCurvePublicKey.from_encoded_point(
+            ec.SECP256R1(), peer_public_bytes
+        )
+        return private_key.exchange(ec.ECDH(), peer_public)
+
+
+# ============================================================================
+# TLS 1.3 Record Layer Encryption
+# ============================================================================
+
+class TLS13RecordProtection:
+    """TLS 1.3 record layer encryption/decryption using AES-GCM."""
+
+    def __init__(self, key, iv):
+        self.key = key
+        self.iv = iv
+        self.seq_num = 0
+        self._aesgcm = AESGCM(key)
+
+    def _compute_nonce(self):
+        """Compute per-record nonce: IV XOR sequence number."""
+        seq_bytes = self.seq_num.to_bytes(len(self.iv), byteorder='big')
+        nonce = bytes(a ^ b for a, b in zip(self.iv, seq_bytes))
+        self.seq_num += 1
+        return nonce
+
+    def encrypt(self, content_type, plaintext):
+        """
+        Encrypt a TLS 1.3 record.
+
+        TLSInnerPlaintext = plaintext + content_type(1 byte)
+        TLSCiphertext = AES-GCM(nonce, aad=header, plaintext=TLSInnerPlaintext)
+        """
+        # TLSInnerPlaintext: data + content type byte
+        inner = plaintext + struct.pack("B", content_type)
+        nonce = self._compute_nonce()
+
+        # Build header first to use as AAD
+        # Encrypted length = inner length + 16 bytes GCM tag
+        length = len(inner) + 16
+        header = struct.pack("!BHH", 0x17, 0x0303, length)
+
+        encrypted = self._aesgcm.encrypt(nonce, inner, header)
+
+        return header + encrypted
+
+    def decrypt(self, ciphertext, record_header=None):
+        """
+        Decrypt a TLS 1.3 record.
+
+        Returns (content_type, plaintext).
+        """
+        nonce = self._compute_nonce()
+        aad = record_header  # AAD is the 5-byte record header in TLS 1.3
+
+        inner = self._aesgcm.decrypt(nonce, ciphertext, aad)
+
+        # Strip padding zeros and extract content type (last non-zero byte)
+        # TLSInnerPlaintext: content + content_type + zeros
+        i = len(inner) - 1
+        while i >= 0 and inner[i] == 0:
+            i -= 1
+
+        if i < 0:
+            raise ValueError("TLS 1.3: empty inner plaintext")
+
+        content_type = inner[i]
+        plaintext = inner[:i]
+        return content_type, plaintext

--- a/test/test_tls13.py
+++ b/test/test_tls13.py
@@ -1,0 +1,476 @@
+"""Tests for TLS 1.3 implementation (#6)."""
+
+import hashlib
+import hmac
+import struct
+import os
+import unittest
+
+from ja3requests.protocol.tls.tls13 import (
+    HKDF,
+    TLS13KeySchedule,
+    TLS13KeyExchange,
+    TLS13RecordProtection,
+)
+from ja3requests.protocol.tls.extensions import (
+    SupportedVersionsExtension,
+    KeyShareExtension,
+    PSKKeyExchangeModesExtension,
+)
+
+
+# ============================================================================
+# HKDF Tests
+# ============================================================================
+
+class TestHKDFExtract(unittest.TestCase):
+    """Test HKDF-Extract."""
+
+    def test_extract_deterministic(self):
+        result1 = HKDF.extract(b"salt", b"ikm")
+        result2 = HKDF.extract(b"salt", b"ikm")
+        self.assertEqual(result1, result2)
+
+    def test_extract_output_length(self):
+        result = HKDF.extract(b"salt", b"ikm")
+        self.assertEqual(len(result), 32)  # SHA-256 digest
+
+    def test_extract_different_salts_differ(self):
+        r1 = HKDF.extract(b"salt1", b"ikm")
+        r2 = HKDF.extract(b"salt2", b"ikm")
+        self.assertNotEqual(r1, r2)
+
+    def test_extract_none_salt_uses_zeros(self):
+        result = HKDF.extract(None, b"ikm")
+        expected = HKDF.extract(b"\x00" * 32, b"ikm")
+        self.assertEqual(result, expected)
+
+    def test_extract_sha384(self):
+        result = HKDF.extract(b"salt", b"ikm", hashlib.sha384)
+        self.assertEqual(len(result), 48)
+
+
+class TestHKDFExpand(unittest.TestCase):
+    """Test HKDF-Expand."""
+
+    def test_expand_output_length(self):
+        prk = HKDF.extract(b"salt", b"ikm")
+        result = HKDF.expand(prk, b"info", 42)
+        self.assertEqual(len(result), 42)
+
+    def test_expand_different_lengths(self):
+        prk = HKDF.extract(b"salt", b"ikm")
+        r16 = HKDF.expand(prk, b"info", 16)
+        r32 = HKDF.expand(prk, b"info", 32)
+        # Shorter should be prefix of longer
+        self.assertEqual(r16, r32[:16])
+
+    def test_expand_different_info(self):
+        prk = HKDF.extract(b"salt", b"ikm")
+        r1 = HKDF.expand(prk, b"info1", 32)
+        r2 = HKDF.expand(prk, b"info2", 32)
+        self.assertNotEqual(r1, r2)
+
+
+class TestHKDFExpandLabel(unittest.TestCase):
+    """Test HKDF-Expand-Label for TLS 1.3."""
+
+    def test_expand_label_output_length(self):
+        prk = os.urandom(32)
+        result = HKDF.expand_label(prk, "key", b"", 16)
+        self.assertEqual(len(result), 16)
+
+    def test_expand_label_different_labels(self):
+        prk = os.urandom(32)
+        r1 = HKDF.expand_label(prk, "key", b"", 16)
+        r2 = HKDF.expand_label(prk, "iv", b"", 16)
+        self.assertNotEqual(r1, r2)
+
+    def test_expand_label_with_context(self):
+        prk = os.urandom(32)
+        r1 = HKDF.expand_label(prk, "key", b"context1", 16)
+        r2 = HKDF.expand_label(prk, "key", b"context2", 16)
+        self.assertNotEqual(r1, r2)
+
+    def test_expand_label_deterministic(self):
+        prk = b"\x01" * 32
+        r1 = HKDF.expand_label(prk, "test", b"ctx", 16)
+        r2 = HKDF.expand_label(prk, "test", b"ctx", 16)
+        self.assertEqual(r1, r2)
+
+
+class TestDeriveSecret(unittest.TestCase):
+    """Test Derive-Secret."""
+
+    def test_derive_secret_output_length(self):
+        secret = os.urandom(32)
+        result = HKDF.derive_secret(secret, "label", b"messages")
+        self.assertEqual(len(result), 32)  # SHA-256
+
+    def test_derive_secret_different_messages(self):
+        secret = os.urandom(32)
+        r1 = HKDF.derive_secret(secret, "label", b"msg1")
+        r2 = HKDF.derive_secret(secret, "label", b"msg2")
+        self.assertNotEqual(r1, r2)
+
+
+# ============================================================================
+# Key Schedule Tests
+# ============================================================================
+
+class TestTLS13KeySchedule(unittest.TestCase):
+    """Test the full TLS 1.3 key schedule."""
+
+    def test_early_secret(self):
+        ks = TLS13KeySchedule()
+        es = ks.compute_early_secret()
+        self.assertEqual(len(es), 32)
+        self.assertIsNotNone(ks.early_secret)
+
+    def test_handshake_secret(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        shared = os.urandom(32)
+        hs = ks.compute_handshake_secret(shared, b"hello_messages")
+        self.assertEqual(len(hs), 32)
+        self.assertIsNotNone(ks.client_handshake_traffic_secret)
+        self.assertIsNotNone(ks.server_handshake_traffic_secret)
+
+    def test_master_secret(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        ks.compute_handshake_secret(os.urandom(32), b"hello")
+        ms = ks.compute_master_secret(b"all_handshake_messages")
+        self.assertEqual(len(ms), 32)
+        self.assertIsNotNone(ks.client_application_traffic_secret)
+        self.assertIsNotNone(ks.server_application_traffic_secret)
+
+    def test_traffic_key_derivation(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        ks.compute_handshake_secret(os.urandom(32))
+        key, iv = ks.derive_traffic_keys(ks.server_handshake_traffic_secret)
+        self.assertEqual(len(key), 16)
+        self.assertEqual(len(iv), 12)
+
+    def test_traffic_key_256bit(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        ks.compute_handshake_secret(os.urandom(32))
+        key, iv = ks.derive_traffic_keys(ks.server_handshake_traffic_secret, key_length=32)
+        self.assertEqual(len(key), 32)
+
+    def test_finished_key(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        ks.compute_handshake_secret(os.urandom(32))
+        fk = ks.compute_finished_key(ks.client_handshake_traffic_secret)
+        self.assertEqual(len(fk), 32)
+
+    def test_finished_verify_data(self):
+        ks = TLS13KeySchedule()
+        ks.compute_early_secret()
+        ks.compute_handshake_secret(os.urandom(32))
+        fk = ks.compute_finished_key(ks.client_handshake_traffic_secret)
+        vd = ks.compute_finished_verify_data(fk, b"handshake_context")
+        self.assertEqual(len(vd), 32)
+
+    def test_full_key_schedule_deterministic(self):
+        """Same inputs produce same outputs."""
+        shared = b"\x42" * 32
+        for _ in range(2):
+            ks = TLS13KeySchedule()
+            ks.compute_early_secret()
+            ks.compute_handshake_secret(shared, b"hello")
+            ms1 = ks.compute_master_secret(b"all")
+
+        ks2 = TLS13KeySchedule()
+        ks2.compute_early_secret()
+        ks2.compute_handshake_secret(shared, b"hello")
+        ms2 = ks2.compute_master_secret(b"all")
+        self.assertEqual(ms1, ms2)
+
+    def test_different_shared_secret_produces_different_keys(self):
+        ks1 = TLS13KeySchedule()
+        ks1.compute_early_secret()
+        ks1.compute_handshake_secret(b"\x01" * 32)
+
+        ks2 = TLS13KeySchedule()
+        ks2.compute_early_secret()
+        ks2.compute_handshake_secret(b"\x02" * 32)
+
+        self.assertNotEqual(
+            ks1.client_handshake_traffic_secret,
+            ks2.client_handshake_traffic_secret,
+        )
+
+
+# ============================================================================
+# Key Exchange Tests
+# ============================================================================
+
+class TestTLS13KeyExchange(unittest.TestCase):
+    """Test TLS 1.3 ECDHE key exchange."""
+
+    def test_x25519_keypair(self):
+        priv, pub = TLS13KeyExchange.generate_x25519_keypair()
+        self.assertEqual(len(pub), 32)
+        self.assertIsNotNone(priv)
+
+    def test_x25519_shared_secret(self):
+        priv1, pub1 = TLS13KeyExchange.generate_x25519_keypair()
+        priv2, pub2 = TLS13KeyExchange.generate_x25519_keypair()
+        ss1 = TLS13KeyExchange.compute_x25519_shared_secret(priv1, pub2)
+        ss2 = TLS13KeyExchange.compute_x25519_shared_secret(priv2, pub1)
+        self.assertEqual(ss1, ss2)  # Both sides compute same secret
+        self.assertEqual(len(ss1), 32)
+
+    def test_secp256r1_keypair(self):
+        priv, pub = TLS13KeyExchange.generate_secp256r1_keypair()
+        self.assertEqual(len(pub), 65)  # Uncompressed point
+        self.assertEqual(pub[0], 0x04)  # Uncompressed prefix
+
+    def test_secp256r1_shared_secret(self):
+        priv1, pub1 = TLS13KeyExchange.generate_secp256r1_keypair()
+        priv2, pub2 = TLS13KeyExchange.generate_secp256r1_keypair()
+        ss1 = TLS13KeyExchange.compute_secp256r1_shared_secret(priv1, pub2)
+        ss2 = TLS13KeyExchange.compute_secp256r1_shared_secret(priv2, pub1)
+        self.assertEqual(ss1, ss2)
+        self.assertEqual(len(ss1), 32)
+
+
+# ============================================================================
+# Record Protection Tests
+# ============================================================================
+
+class TestTLS13RecordProtection(unittest.TestCase):
+    """Test TLS 1.3 record encryption/decryption."""
+
+    def test_encrypt_decrypt_roundtrip(self):
+        key = os.urandom(16)
+        iv = os.urandom(12)
+        enc = TLS13RecordProtection(key, iv)
+        dec = TLS13RecordProtection(key, iv)
+
+        ciphertext_record = enc.encrypt(0x17, b"hello world")
+        # Extract ciphertext (skip 5-byte header)
+        header = ciphertext_record[:5]
+        ciphertext = ciphertext_record[5:]
+        content_type, plaintext = dec.decrypt(ciphertext, header)
+        self.assertEqual(plaintext, b"hello world")
+        self.assertEqual(content_type, 0x17)
+
+    def test_sequence_number_increments(self):
+        key = os.urandom(16)
+        iv = os.urandom(12)
+        rp = TLS13RecordProtection(key, iv)
+        self.assertEqual(rp.seq_num, 0)
+        rp.encrypt(0x17, b"msg1")
+        self.assertEqual(rp.seq_num, 1)
+        rp.encrypt(0x17, b"msg2")
+        self.assertEqual(rp.seq_num, 2)
+
+    def test_different_messages_different_ciphertext(self):
+        key = os.urandom(16)
+        iv = os.urandom(12)
+        rp = TLS13RecordProtection(key, iv)
+        ct1 = rp.encrypt(0x17, b"message1")
+        ct2 = rp.encrypt(0x17, b"message2")
+        self.assertNotEqual(ct1, ct2)
+
+    def test_256bit_key(self):
+        key = os.urandom(32)
+        iv = os.urandom(12)
+        enc = TLS13RecordProtection(key, iv)
+        dec = TLS13RecordProtection(key, iv)
+        ct = enc.encrypt(0x16, b"handshake data")
+        header = ct[:5]
+        ciphertext = ct[5:]
+        content_type, plaintext = dec.decrypt(ciphertext, header)
+        self.assertEqual(plaintext, b"handshake data")
+        self.assertEqual(content_type, 0x16)
+
+    def test_record_header_format(self):
+        key = os.urandom(16)
+        iv = os.urandom(12)
+        rp = TLS13RecordProtection(key, iv)
+        ct = rp.encrypt(0x17, b"data")
+        # Header: type=0x17 (app data), version=0x0303, length
+        self.assertEqual(ct[0], 0x17)
+        self.assertEqual(ct[1:3], b"\x03\x03")
+
+
+# ============================================================================
+# Extension Tests
+# ============================================================================
+
+class TestSupportedVersionsExtension(unittest.TestCase):
+    """Test supported_versions extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(SupportedVersionsExtension.extension_type, 0x002B)
+
+    def test_default_versions(self):
+        ext = SupportedVersionsExtension()
+        self.assertEqual(ext.versions, [0x0304, 0x0303])
+
+    def test_encode(self):
+        ext = SupportedVersionsExtension([0x0304, 0x0303])
+        data = ext.encode()
+        # 1 byte length + 2 bytes per version
+        self.assertEqual(data[0], 4)  # 2 versions * 2 bytes
+        v1 = struct.unpack("!H", data[1:3])[0]
+        v2 = struct.unpack("!H", data[3:5])[0]
+        self.assertEqual(v1, 0x0304)
+        self.assertEqual(v2, 0x0303)
+
+    def test_to_bytes(self):
+        ext = SupportedVersionsExtension()
+        raw = ext.to_bytes()
+        ext_type = struct.unpack("!H", raw[:2])[0]
+        self.assertEqual(ext_type, 0x002B)
+
+
+class TestKeyShareExtension(unittest.TestCase):
+    """Test key_share extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(KeyShareExtension.extension_type, 0x0033)
+
+    def test_encode_x25519(self):
+        pub = os.urandom(32)
+        ext = KeyShareExtension([(0x001D, pub)])
+        data = ext.encode()
+        # 2 bytes entries length, then: 2 bytes group + 2 bytes key length + key
+        entries_len = struct.unpack("!H", data[:2])[0]
+        self.assertEqual(entries_len, 2 + 2 + 32)
+        group = struct.unpack("!H", data[2:4])[0]
+        self.assertEqual(group, 0x001D)
+        key_len = struct.unpack("!H", data[4:6])[0]
+        self.assertEqual(key_len, 32)
+
+    def test_encode_multiple_shares(self):
+        ext = KeyShareExtension([
+            (0x001D, os.urandom(32)),
+            (0x0017, os.urandom(65)),
+        ])
+        data = ext.encode()
+        entries_len = struct.unpack("!H", data[:2])[0]
+        expected = (2 + 2 + 32) + (2 + 2 + 65)
+        self.assertEqual(entries_len, expected)
+
+
+class TestPSKKeyExchangeModesExtension(unittest.TestCase):
+    """Test psk_key_exchange_modes extension."""
+
+    def test_extension_type(self):
+        self.assertEqual(PSKKeyExchangeModesExtension.extension_type, 0x002D)
+
+    def test_default_mode(self):
+        ext = PSKKeyExchangeModesExtension()
+        data = ext.encode()
+        self.assertEqual(data[0], 1)  # 1 mode
+        self.assertEqual(data[1], 1)  # psk_dhe_ke
+
+
+# ============================================================================
+# TLS Integration Tests
+# ============================================================================
+
+class TestTLS13SetupInTLS(unittest.TestCase):
+    """Test TLS 1.3 setup in TLS class."""
+
+    def test_tls13_flag_set(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        s1, s2 = socket.socketpair()
+        try:
+            config = TlsConfig()
+            config.tls_version = 0x0304
+            config.server_name = "example.com"
+            tls = TLS(s1)
+            tls.set_payload(tls_config=config)
+            self.assertTrue(tls._is_tls13)
+            self.assertIsNotNone(tls._tls13_private_key)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_tls12_flag_not_set(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        s1, s2 = socket.socketpair()
+        try:
+            config = TlsConfig()
+            config.tls_version = 0x0303
+            tls = TLS(s1)
+            tls.set_payload(tls_config=config)
+            self.assertFalse(tls._is_tls13)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_tls13_client_hello_has_supported_versions(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        s1, s2 = socket.socketpair()
+        try:
+            config = TlsConfig()
+            config.tls_version = 0x0304
+            config.server_name = "example.com"
+            tls = TLS(s1)
+            tls.set_payload(tls_config=config)
+            # Check ClientHello extensions contain supported_versions (0x002B)
+            ext_data = tls._body.extensions
+            self.assertIn(struct.pack("!H", 0x002B), ext_data)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_tls13_client_hello_has_key_share(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        s1, s2 = socket.socketpair()
+        try:
+            config = TlsConfig()
+            config.tls_version = 0x0304
+            config.server_name = "example.com"
+            tls = TLS(s1)
+            tls.set_payload(tls_config=config)
+            ext_data = tls._body.extensions
+            # key_share extension type 0x0033
+            self.assertIn(struct.pack("!H", 0x0033), ext_data)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_tls13_client_hello_version_is_0303(self):
+        """TLS 1.3 ClientHello version field should be 0x0303 for compatibility."""
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.config import TlsConfig
+
+        s1, s2 = socket.socketpair()
+        try:
+            config = TlsConfig()
+            config.tls_version = 0x0304
+            config.server_name = "example.com"
+            tls = TLS(s1)
+            tls.set_payload(tls_config=config)
+            # ClientHello.version should be 0x0303, not 0x0304
+            self.assertEqual(tls._body.version, b"\x03\x03")
+        finally:
+            s1.close()
+            s2.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

TLS 1.3 foundation (Phases 1-4):

- **HKDF**: Extract, Expand, Expand-Label, Derive-Secret (RFC 5869/8446)
- **TLS13KeySchedule**: Early → Handshake → Master secret chain, traffic key derivation, Finished verify_data
- **TLS13KeyExchange**: x25519 and secp256r1 ECDHE key pair generation and shared secret computation
- **TLS13RecordProtection**: AES-GCM encrypt/decrypt with per-record nonce XOR, record header AAD
- **Extensions**: SupportedVersions (0x002B), KeyShare (0x0033), PSKKeyExchangeModes (0x002D)
- **TLS integration**: auto-detect TLS 1.3 config, inject extensions + key_share, set compatibility version 0x0303

Note: Full handshake flow (encrypted ServerHello parsing, EncryptedExtensions, server Finished) is a follow-up.

## Test plan

- [x] 46 tests pass (HKDF, key schedule, key exchange, record protection, extensions, TLS integration)
- [x] Full suite: 407 tests pass

Closes #6

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL