### PR TITLE
feat: TLS 1.3 handshake completion, Session Ticket, IDN Punycode

### DIFF
--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -277,6 +277,33 @@ class TLS:
             )
             debug(f"Saved TLS session for {self._server_host}:{self._server_port}")
 
+    def _parse_new_session_ticket(self, data):
+        """
+        Parse NewSessionTicket message (handshake type 4) and cache ticket.
+        TLS 1.2: lifetime(4) + ticket_data
+        """
+        if len(data) < 6:
+            return
+        lifetime = struct.unpack("!I", data[:4])[0]
+        ticket_len = struct.unpack("!H", data[4:6])[0]
+        if len(data) < 6 + ticket_len:
+            return
+        ticket = data[6:6 + ticket_len]
+        debug(f"Received NewSessionTicket: lifetime={lifetime}s, ticket_len={ticket_len}")
+
+        # Store ticket as session ID for resumption
+        if self._session_cache is not None and self._server_host and self._master_secret:
+            cipher = getattr(self, '_selected_cipher_suite', 0)
+            self._session_cache.put(
+                self._server_host,
+                self._server_port or 443,
+                ticket,  # Use ticket as session ID
+                self._master_secret,
+                cipher,
+                tls_version=self._tls_version,
+            )
+            debug(f"Cached session ticket for {self._server_host}")
+
     def _parse_server_handshake_messages(
         self,
     ):  # pylint: disable=too-many-branches,too-many-statements,too-many-nested-blocks

--- a/ja3requests/protocol/tls/extensions/__init__.py
+++ b/ja3requests/protocol/tls/extensions/__init__.py
@@ -55,7 +55,15 @@ class SNIExtension(Extension):
         self.server_name = server_name
 
     def encode(self):
-        name_bytes = self.server_name.encode('utf-8')
+        # Convert internationalized domain names to Punycode (RFC 5890)
+        name = self.server_name
+        try:
+            name.encode('ascii')
+        except UnicodeEncodeError:
+            # Non-ASCII domain: convert to IDNA/Punycode
+            name = name.encode('idna').decode('ascii')
+
+        name_bytes = name.encode('ascii')
         # ServerNameList: 2 bytes list length
         #   ServerName: 1 byte name type (0 = hostname) + 2 bytes name length + name
         sni_entry = struct.pack("!BH", 0, len(name_bytes)) + name_bytes

--- a/ja3requests/protocol/tls/tls13.py
+++ b/ja3requests/protocol/tls/tls13.py
@@ -326,3 +326,233 @@ class TLS13RecordProtection:
         content_type = inner[i]
         plaintext = inner[:i]
         return content_type, plaintext
+
+
+# ============================================================================
+# TLS 1.3 Handshake Handler
+# ============================================================================
+
+# Named group IDs
+GROUP_X25519 = 0x001D
+GROUP_SECP256R1 = 0x0017
+
+# Cipher suite → (key_length, hash_algo)
+TLS13_CIPHER_PARAMS = {
+    0x1301: (16, hashlib.sha256),  # TLS_AES_128_GCM_SHA256
+    0x1302: (32, hashlib.sha384),  # TLS_AES_256_GCM_SHA384
+    0x1303: (32, hashlib.sha256),  # TLS_CHACHA20_POLY1305_SHA256
+}
+
+
+class TLS13Handshake:
+    """
+    TLS 1.3 handshake state machine.
+
+    Orchestrates: ClientHello → ServerHello → [encrypted handshake] → Finished
+    Using the HKDF key schedule, key exchange, and record protection primitives.
+    """
+
+    def __init__(self, conn, private_key, key_share_group, client_hello_bytes):
+        """
+        :param conn: Raw TCP socket
+        :param private_key: ECDHE private key (from ClientHello key_share)
+        :param key_share_group: Named group ID used in key_share
+        :param client_hello_bytes: Raw ClientHello handshake message (for transcript)
+        """
+        self.conn = conn
+        self._private_key = private_key
+        self._key_share_group = key_share_group
+        self._transcript = client_hello_bytes  # Accumulates handshake messages
+        self._key_schedule = None
+        self._server_handshake_rp = None  # Record protection for decrypting server
+        self._client_handshake_rp = None  # Record protection for encrypting to server
+        self._server_app_rp = None
+        self._client_app_rp = None
+        self._cipher_suite = None
+        self._hash_algo = hashlib.sha256
+        self._key_length = 16
+        self._cipher_type = "aes-gcm"
+
+    def process_server_hello(self, server_hello_data):
+        """
+        Parse ServerHello, extract key_share, compute shared secret,
+        and derive handshake traffic keys.
+
+        :param server_hello_data: Raw ServerHello handshake message bytes
+        :return: True if successful
+        """
+        self._transcript += server_hello_data
+
+        # Parse ServerHello to extract cipher suite and key_share
+        offset = 0
+        if len(server_hello_data) < 38:
+            return False
+
+        # Version (2) + Random (32) = 34 bytes
+        offset = 2 + 32
+
+        # Session ID
+        if offset >= len(server_hello_data):
+            return False
+        sid_len = server_hello_data[offset]
+        offset += 1 + sid_len
+
+        # Cipher suite
+        if offset + 2 > len(server_hello_data):
+            return False
+        self._cipher_suite = struct.unpack("!H", server_hello_data[offset:offset + 2])[0]
+        offset += 2
+
+        # Compression
+        offset += 1
+
+        # Configure cipher parameters
+        if self._cipher_suite in TLS13_CIPHER_PARAMS:
+            self._key_length, self._hash_algo = TLS13_CIPHER_PARAMS[self._cipher_suite]
+        if self._cipher_suite == 0x1303:
+            self._cipher_type = "chacha20-poly1305"
+
+        # Parse extensions to find key_share
+        server_public_key = None
+        server_group = None
+        if offset + 2 <= len(server_hello_data):
+            ext_length = struct.unpack("!H", server_hello_data[offset:offset + 2])[0]
+            offset += 2
+            ext_end = offset + ext_length
+
+            while offset + 4 <= ext_end:
+                ext_type = struct.unpack("!H", server_hello_data[offset:offset + 2])[0]
+                ext_len = struct.unpack("!H", server_hello_data[offset + 2:offset + 4])[0]
+                offset += 4
+                ext_data = server_hello_data[offset:offset + ext_len]
+                offset += ext_len
+
+                if ext_type == 0x0033:  # key_share
+                    if len(ext_data) >= 4:
+                        server_group = struct.unpack("!H", ext_data[:2])[0]
+                        key_len = struct.unpack("!H", ext_data[2:4])[0]
+                        server_public_key = ext_data[4:4 + key_len]
+
+        if server_public_key is None:
+            debug("TLS 1.3: No key_share in ServerHello")
+            return False
+
+        # Compute shared secret
+        if server_group == GROUP_X25519:
+            shared_secret = TLS13KeyExchange.compute_x25519_shared_secret(
+                self._private_key, server_public_key
+            )
+        elif server_group == GROUP_SECP256R1:
+            shared_secret = TLS13KeyExchange.compute_secp256r1_shared_secret(
+                self._private_key, server_public_key
+            )
+        else:
+            debug(f"TLS 1.3: Unsupported group 0x{server_group:04X}")
+            return False
+
+        debug(f"TLS 1.3: Shared secret computed ({len(shared_secret)} bytes)")
+
+        # Derive handshake traffic keys
+        self._key_schedule = TLS13KeySchedule(self._hash_algo)
+        self._key_schedule.compute_early_secret()
+        self._key_schedule.compute_handshake_secret(shared_secret, self._transcript)
+
+        # Create record protection for handshake phase
+        s_key, s_iv = self._key_schedule.derive_traffic_keys(
+            self._key_schedule.server_handshake_traffic_secret, self._key_length
+        )
+        c_key, c_iv = self._key_schedule.derive_traffic_keys(
+            self._key_schedule.client_handshake_traffic_secret, self._key_length
+        )
+
+        self._server_handshake_rp = TLS13RecordProtection(s_key, s_iv, self._cipher_type)
+        self._client_handshake_rp = TLS13RecordProtection(c_key, c_iv, self._cipher_type)
+
+        debug("TLS 1.3: Handshake traffic keys derived")
+        return True
+
+    def decrypt_handshake_record(self, ciphertext, record_header):
+        """Decrypt a server handshake record and add to transcript."""
+        content_type, plaintext = self._server_handshake_rp.decrypt(ciphertext, record_header)
+        if content_type == 0x16:  # Handshake
+            self._transcript += plaintext
+        return content_type, plaintext
+
+    def parse_encrypted_handshake(self, plaintext):
+        """
+        Parse decrypted handshake messages (EncryptedExtensions,
+        Certificate, CertificateVerify, Finished).
+
+        :return: List of (msg_type, msg_data) tuples
+        """
+        messages = []
+        offset = 0
+        while offset + 4 <= len(plaintext):
+            msg_type = plaintext[offset]
+            msg_len = struct.unpack("!I", b"\x00" + plaintext[offset + 1:offset + 4])[0]
+            offset += 4
+            msg_data = plaintext[offset:offset + msg_len]
+            offset += msg_len
+            messages.append((msg_type, msg_data))
+            debug(f"TLS 1.3: Parsed handshake message type={msg_type} len={msg_len}")
+        return messages
+
+    def verify_server_finished(self, finished_data):
+        """
+        Verify the server's Finished message.
+
+        :param finished_data: The verify_data from server's Finished message
+        :return: True if valid
+        """
+        finished_key = self._key_schedule.compute_finished_key(
+            self._key_schedule.server_handshake_traffic_secret
+        )
+        # Transcript up to (but not including) server Finished
+        expected = self._key_schedule.compute_finished_verify_data(
+            finished_key, self._transcript
+        )
+        return hmac.compare_digest(finished_data, expected)
+
+    def build_client_finished(self):
+        """
+        Build and encrypt the client's Finished message.
+
+        :return: Encrypted TLS record bytes ready to send
+        """
+        finished_key = self._key_schedule.compute_finished_key(
+            self._key_schedule.client_handshake_traffic_secret
+        )
+        verify_data = self._key_schedule.compute_finished_verify_data(
+            finished_key, self._transcript
+        )
+
+        # Finished message: type(1) + length(3) + verify_data
+        finished_msg = struct.pack("B", 20)  # Finished type
+        finished_msg += struct.pack("!I", len(verify_data))[1:]
+        finished_msg += verify_data
+
+        self._transcript += finished_msg
+
+        # Encrypt with client handshake key
+        return self._client_handshake_rp.encrypt(0x16, finished_msg)
+
+    def derive_application_keys(self):
+        """
+        Derive application traffic keys after handshake completion.
+
+        :return: (client_app_rp, server_app_rp)
+        """
+        self._key_schedule.compute_master_secret(self._transcript)
+
+        s_key, s_iv = self._key_schedule.derive_traffic_keys(
+            self._key_schedule.server_application_traffic_secret, self._key_length
+        )
+        c_key, c_iv = self._key_schedule.derive_traffic_keys(
+            self._key_schedule.client_application_traffic_secret, self._key_length
+        )
+
+        self._server_app_rp = TLS13RecordProtection(s_key, s_iv, self._cipher_type)
+        self._client_app_rp = TLS13RecordProtection(c_key, c_iv, self._cipher_type)
+
+        debug("TLS 1.3: Application traffic keys derived")
+        return self._client_app_rp, self._server_app_rp

--- a/test/test_tls13_handshake.py
+++ b/test/test_tls13_handshake.py
@@ -1,0 +1,274 @@
+"""Tests for TLS 1.3 handshake, Session Ticket, and IDN Punycode."""
+
+import hashlib
+import os
+import struct
+import unittest
+
+from ja3requests.protocol.tls.tls13 import (
+    TLS13Handshake,
+    TLS13KeySchedule,
+    TLS13KeyExchange,
+    TLS13RecordProtection,
+    GROUP_X25519,
+    GROUP_SECP256R1,
+    TLS13_CIPHER_PARAMS,
+)
+from ja3requests.protocol.tls.extensions import SNIExtension
+
+
+# ============================================================================
+# TLS 1.3 Handshake Tests
+# ============================================================================
+
+class TestTLS13HandshakeInit(unittest.TestCase):
+    def test_create_handshake(self):
+        priv, pub = TLS13KeyExchange.generate_x25519_keypair()
+        hs = TLS13Handshake(None, priv, GROUP_X25519, b"client_hello_data")
+        self.assertIsNotNone(hs)
+        self.assertEqual(hs._transcript, b"client_hello_data")
+
+    def test_cipher_params(self):
+        self.assertIn(0x1301, TLS13_CIPHER_PARAMS)
+        self.assertIn(0x1302, TLS13_CIPHER_PARAMS)
+        self.assertIn(0x1303, TLS13_CIPHER_PARAMS)
+
+
+class TestTLS13ServerHelloParsing(unittest.TestCase):
+    """Test process_server_hello with synthetic ServerHello data."""
+
+    def _build_server_hello(self, cipher_suite=0x1301, group=GROUP_X25519, pub_key=None):
+        """Build a synthetic ServerHello with key_share extension."""
+        if pub_key is None:
+            _, pub_key = TLS13KeyExchange.generate_x25519_keypair()
+
+        version = b"\x03\x03"
+        random_bytes = os.urandom(32)
+        session_id = b"\x00"
+        cipher = struct.pack("!H", cipher_suite)
+        compression = b"\x00"
+
+        # key_share extension
+        key_share_data = struct.pack("!HH", group, len(pub_key)) + pub_key
+        key_share_ext = struct.pack("!HH", 0x0033, len(key_share_data)) + key_share_data
+
+        # supported_versions extension
+        sv_data = struct.pack("!H", 0x0304)
+        sv_ext = struct.pack("!HH", 0x002B, len(sv_data)) + sv_data
+
+        extensions = key_share_ext + sv_ext
+        ext_block = struct.pack("!H", len(extensions)) + extensions
+
+        return version + random_bytes + session_id + cipher + compression + ext_block
+
+    def test_process_server_hello_x25519(self):
+        client_priv, client_pub = TLS13KeyExchange.generate_x25519_keypair()
+        server_priv, server_pub = TLS13KeyExchange.generate_x25519_keypair()
+
+        client_hello = b"fake_client_hello"
+        hs = TLS13Handshake(None, client_priv, GROUP_X25519, client_hello)
+        server_hello = self._build_server_hello(pub_key=server_pub)
+
+        result = hs.process_server_hello(server_hello)
+        self.assertTrue(result)
+        self.assertIsNotNone(hs._key_schedule)
+        self.assertIsNotNone(hs._server_handshake_rp)
+        self.assertIsNotNone(hs._client_handshake_rp)
+        self.assertEqual(hs._cipher_suite, 0x1301)
+
+    def test_process_server_hello_secp256r1(self):
+        client_priv, client_pub = TLS13KeyExchange.generate_secp256r1_keypair()
+        server_priv, server_pub = TLS13KeyExchange.generate_secp256r1_keypair()
+
+        hs = TLS13Handshake(None, client_priv, GROUP_SECP256R1, b"ch")
+        server_hello = self._build_server_hello(
+            group=GROUP_SECP256R1, pub_key=server_pub
+        )
+        self.assertTrue(hs.process_server_hello(server_hello))
+
+    def test_process_server_hello_chacha20(self):
+        client_priv, _ = TLS13KeyExchange.generate_x25519_keypair()
+        _, server_pub = TLS13KeyExchange.generate_x25519_keypair()
+
+        hs = TLS13Handshake(None, client_priv, GROUP_X25519, b"ch")
+        server_hello = self._build_server_hello(cipher_suite=0x1303, pub_key=server_pub)
+        self.assertTrue(hs.process_server_hello(server_hello))
+        self.assertEqual(hs._cipher_type, "chacha20-poly1305")
+
+    def test_process_server_hello_too_short(self):
+        hs = TLS13Handshake(None, None, GROUP_X25519, b"ch")
+        self.assertFalse(hs.process_server_hello(b"\x03\x03"))
+
+    def test_process_server_hello_no_key_share(self):
+        client_priv, _ = TLS13KeyExchange.generate_x25519_keypair()
+        hs = TLS13Handshake(None, client_priv, GROUP_X25519, b"ch")
+        # ServerHello without extensions
+        version = b"\x03\x03"
+        server_hello = version + os.urandom(32) + b"\x00" + b"\x13\x01" + b"\x00"
+        self.assertFalse(hs.process_server_hello(server_hello))
+
+
+class TestTLS13EncryptedHandshake(unittest.TestCase):
+    """Test encrypted handshake message parsing and Finished."""
+
+    def _setup_handshake(self):
+        client_priv, client_pub = TLS13KeyExchange.generate_x25519_keypair()
+        server_priv, server_pub = TLS13KeyExchange.generate_x25519_keypair()
+
+        hs = TLS13Handshake(None, client_priv, GROUP_X25519, b"client_hello")
+
+        # Build and process ServerHello
+        version = b"\x03\x03"
+        sh = (version + os.urandom(32) + b"\x00" + b"\x13\x01" + b"\x00")
+        key_share_data = struct.pack("!HH", GROUP_X25519, len(server_pub)) + server_pub
+        key_share_ext = struct.pack("!HH", 0x0033, len(key_share_data)) + key_share_data
+        ext_block = struct.pack("!H", len(key_share_ext)) + key_share_ext
+        server_hello = sh + ext_block
+
+        hs.process_server_hello(server_hello)
+        return hs
+
+    def test_parse_encrypted_handshake_messages(self):
+        hs = self._setup_handshake()
+        # Build fake EncryptedExtensions (type 8)
+        ee_data = b"\x00\x00"  # empty extensions
+        msg = struct.pack("B", 8) + struct.pack("!I", len(ee_data))[1:] + ee_data
+        messages = hs.parse_encrypted_handshake(msg)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0][0], 8)
+
+    def test_build_client_finished(self):
+        hs = self._setup_handshake()
+        finished_record = hs.build_client_finished()
+        self.assertIsInstance(finished_record, bytes)
+        # Should be a TLS record (starts with 0x17 for application data wrapper)
+        self.assertEqual(finished_record[0], 0x17)
+
+    def test_derive_application_keys(self):
+        hs = self._setup_handshake()
+        client_rp, server_rp = hs.derive_application_keys()
+        self.assertIsInstance(client_rp, TLS13RecordProtection)
+        self.assertIsInstance(server_rp, TLS13RecordProtection)
+
+    def test_app_keys_encrypt_decrypt(self):
+        hs = self._setup_handshake()
+        client_rp, server_rp = hs.derive_application_keys()
+
+        # Client encrypts, server decrypts
+        ct = client_rp.encrypt(0x17, b"application data")
+        header = ct[:5]
+        ciphertext = ct[5:]
+        # Can't decrypt with server_rp directly since server_rp is for
+        # decrypting server→client, not client→server. This is by design.
+        # Verify the encryption at least produces valid output.
+        self.assertGreater(len(ct), 5)
+
+
+class TestTLS13DecryptHandshakeRecord(unittest.TestCase):
+    def test_decrypt_and_add_to_transcript(self):
+        """Test that decrypting a handshake record adds plaintext to transcript."""
+        client_priv, _ = TLS13KeyExchange.generate_x25519_keypair()
+        server_priv, server_pub = TLS13KeyExchange.generate_x25519_keypair()
+
+        hs = TLS13Handshake(None, client_priv, GROUP_X25519, b"ch")
+        sh = (b"\x03\x03" + os.urandom(32) + b"\x00" + b"\x13\x01" + b"\x00")
+        ks = struct.pack("!HH", GROUP_X25519, 32) + server_pub
+        ext = struct.pack("!HH", 0x0033, len(ks)) + ks
+        hs.process_server_hello(sh + struct.pack("!H", len(ext)) + ext)
+
+        # Create a separate encryptor with the same keys as server handshake RP
+        # so the seq_num matches for encrypt(0) → decrypt(0)
+        enc_rp = TLS13RecordProtection(
+            hs._server_handshake_rp.key,
+            hs._server_handshake_rp.iv,
+        )
+
+        test_msg = b"\x08\x00\x00\x02\x00\x00"  # EncryptedExtensions
+        ct_record = enc_rp.encrypt(0x16, test_msg)
+        header = ct_record[:5]
+        ciphertext = ct_record[5:]
+
+        transcript_before = len(hs._transcript)
+        content_type, plaintext = hs.decrypt_handshake_record(ciphertext, header)
+        self.assertEqual(content_type, 0x16)
+        self.assertEqual(plaintext, test_msg)
+        self.assertGreater(len(hs._transcript), transcript_before)
+
+
+# ============================================================================
+# NewSessionTicket Tests
+# ============================================================================
+
+class TestNewSessionTicket(unittest.TestCase):
+    def test_parse_new_session_ticket(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.session_cache import TLSSessionCache
+
+        s1, s2 = socket.socketpair()
+        try:
+            cache = TLSSessionCache()
+            tls = TLS(s1, session_cache=cache, server_host="ticket.example.com", server_port=443)
+            tls._master_secret = os.urandom(48)
+            tls._selected_cipher_suite = 0x002F
+
+            # Build NewSessionTicket: lifetime(4) + ticket_len(2) + ticket
+            ticket_data = os.urandom(128)
+            nst = struct.pack("!IH", 3600, len(ticket_data)) + ticket_data
+            tls._parse_new_session_ticket(nst)
+
+            entry = cache.get("ticket.example.com", 443)
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.session_id, ticket_data)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_parse_short_ticket_ignored(self):
+        import socket
+        from ja3requests.protocol.tls import TLS
+        from ja3requests.protocol.tls.session_cache import TLSSessionCache
+
+        s1, s2 = socket.socketpair()
+        try:
+            cache = TLSSessionCache()
+            tls = TLS(s1, session_cache=cache, server_host="t.com", server_port=443)
+            tls._master_secret = os.urandom(48)
+            tls._parse_new_session_ticket(b"\x00")  # Too short
+            self.assertIsNone(cache.get("t.com", 443))
+        finally:
+            s1.close()
+            s2.close()
+
+
+# ============================================================================
+# IDN Punycode Tests
+# ============================================================================
+
+class TestSNIPunycode(unittest.TestCase):
+    def test_ascii_domain_unchanged(self):
+        ext = SNIExtension("example.com")
+        data = ext.encode()
+        self.assertIn(b"example.com", data)
+
+    def test_unicode_domain_converted(self):
+        ext = SNIExtension("例え.jp")
+        data = ext.encode()
+        # Should NOT contain raw unicode bytes
+        self.assertNotIn("例え".encode("utf-8"), data)
+        # Should contain Punycode-encoded version
+        self.assertIn(b"xn--", data)
+
+    def test_mixed_domain(self):
+        ext = SNIExtension("münchen.de")
+        data = ext.encode()
+        self.assertIn(b"xn--", data)
+
+    def test_already_ascii(self):
+        ext = SNIExtension("sub.domain.example.org")
+        data = ext.encode()
+        self.assertIn(b"sub.domain.example.org", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

### TLS 1.3 Handshake (complete flow)
- `TLS13Handshake` state machine: ClientHello → ServerHello → encrypted handshake → app keys
- `process_server_hello()`: parse key_share, compute ECDHE shared secret, derive handshake keys
- `decrypt_handshake_record()` / `parse_encrypted_handshake()`: decrypt and parse EncryptedExtensions, Certificate, CertificateVerify, Finished
- `verify_server_finished()`: HMAC-verify server Finished
- `build_client_finished()`: encrypt client Finished with handshake key
- `derive_application_keys()`: derive final app traffic keys
- Supports: AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305 / x25519, P-256

### Session Ticket (RFC 5077)
- `_parse_new_session_ticket()`: parse lifetime + ticket, cache via `TLSSessionCache`

### IDN Punycode (RFC 5890)
- `SNIExtension.encode()` converts non-ASCII domains to Punycode (e.g., `münchen.de` → `xn--mnchen-3ya.de`)

## Test plan
- [x] 18 new tests (handshake flow, ServerHello parsing, encrypted record, ticket, Punycode)
- [x] 747 total tests pass

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL