### PR TITLE
feat: client certificate, HPACK dynamic table, cookies crash fix

### DIFF
--- a/ja3requests/base/__sessions.py
+++ b/ja3requests/base/__sessions.py
@@ -102,14 +102,14 @@ class BaseSession:
         :return:
         """
         cookies = Ja3RequestsCookieJar()
-        if self._cookies:
+        if len(self._cookies) > 0:
             cookies = self.resolve_cookies(cookies, self._cookies)
 
-        if self.Request.cookies:
-            cookies = self.resolve_cookies(cookies, self.Request.cookies)
+        if self._request is not None and getattr(self._request, 'cookies', None):
+            cookies = self.resolve_cookies(cookies, self._request.cookies)
 
-        if self.response.cookies:
-            cookies = self.resolve_cookies(cookies, self.response.cookies)
+        if self._response is not None and getattr(self._response, 'cookies', None):
+            cookies = self.resolve_cookies(cookies, self._response.cookies)
 
         return cookies
 

--- a/ja3requests/protocol/h2/hpack.py
+++ b/ja3requests/protocol/h2/hpack.py
@@ -169,12 +169,15 @@ def decode_string(data, offset):
 
 class HPACKEncoder:
     """
-    Simplified HPACK encoder.
-    Uses static table + literal headers without indexing.
+    HPACK encoder with static and dynamic table support.
+    Uses incremental indexing for repeated headers to improve compression.
     """
 
+    MAX_DYNAMIC_TABLE_SIZE = 4096
+
     def __init__(self):
-        self.dynamic_table = []
+        self.dynamic_table = []  # List of (name, value) tuples, newest first
+        self._dynamic_table_size = 0
 
     def encode_headers(self, headers):
         """
@@ -188,28 +191,71 @@ class HPACKEncoder:
             result += self._encode_header(name, value)
         return result
 
+    def _find_in_dynamic_table(self, name, value):
+        """Search dynamic table for exact match or name match.
+        Returns (exact_index, name_index) where index is 1-based from static table end.
+        """
+        name_match = None
+        for i, (n, v) in enumerate(self.dynamic_table):
+            idx = len(STATIC_TABLE) + i
+            if n == name and v == value:
+                return idx, idx  # exact match
+            if n == name and name_match is None:
+                name_match = idx
+        return None, name_match
+
+    def _add_to_dynamic_table(self, name, value):
+        """Add a header to the dynamic table."""
+        entry_size = len(name) + len(value) + 32  # per RFC 7541 Section 4.1
+        # Evict entries if table would exceed max size
+        while self._dynamic_table_size + entry_size > self.MAX_DYNAMIC_TABLE_SIZE and self.dynamic_table:
+            evicted = self.dynamic_table.pop()
+            self._dynamic_table_size -= len(evicted[0]) + len(evicted[1]) + 32
+
+        if entry_size <= self.MAX_DYNAMIC_TABLE_SIZE:
+            self.dynamic_table.insert(0, (name, value))
+            self._dynamic_table_size += entry_size
+
     def _encode_header(self, name, value):
         """Encode a single header field."""
         name_lower = name.lower() if isinstance(name, str) else name.decode().lower()
 
-        # Check static table for exact match
+        # Check static table for exact match → indexed
         pair_key = (name_lower, value)
         if pair_key in _STATIC_PAIR_INDEX:
             idx = _STATIC_PAIR_INDEX[pair_key]
             return encode_integer(idx, 7, 0x80)
 
-        # Check static table for name match → literal with name index
-        if name_lower in _STATIC_NAME_INDEX:
-            idx = _STATIC_NAME_INDEX[name_lower]
-            # Literal without indexing (0000xxxx)
-            result = encode_integer(idx, 4, 0x00)
+        # Check dynamic table for exact match → indexed
+        exact_idx, name_idx = self._find_in_dynamic_table(name_lower, value)
+        if exact_idx is not None:
+            return encode_integer(exact_idx, 7, 0x80)
+
+        # Sensitive headers: literal without indexing (never indexed)
+        if name_lower in ("authorization", "proxy-authorization", "cookie", "set-cookie"):
+            if name_lower in _STATIC_NAME_INDEX:
+                idx = _STATIC_NAME_INDEX[name_lower]
+                result = encode_integer(idx, 4, 0x10)  # Never indexed
+            else:
+                result = b"\x10"
+                result += encode_string(name_lower)
             result += encode_string(value)
             return result
 
-        # Literal without indexing, new name
-        result = b"\x00"  # 0000 0000
-        result += encode_string(name_lower)
-        result += encode_string(value)
+        # Non-sensitive headers: literal with incremental indexing → adds to dynamic table
+        if name_lower in _STATIC_NAME_INDEX:
+            idx = _STATIC_NAME_INDEX[name_lower]
+            result = encode_integer(idx, 6, 0x40)
+            result += encode_string(value)
+        elif name_idx is not None:
+            result = encode_integer(name_idx, 6, 0x40)
+            result += encode_string(value)
+        else:
+            result = b"\x40"  # 0100 0000, new name
+            result += encode_string(name_lower)
+            result += encode_string(value)
+
+        self._add_to_dynamic_table(name_lower, value)
         return result
 
 

--- a/ja3requests/protocol/tls/__init__.py
+++ b/ja3requests/protocol/tls/__init__.py
@@ -151,6 +151,13 @@ class TLS:
             else:
                 self._verify_cert = False  # Default to False for backward compatibility
 
+            # Load client certificate if configured
+            if getattr(tls_config, 'client_cert', None):
+                self._client_cert_pem = self._load_cert_data(tls_config.client_cert)
+                self._client_key_pem = self._load_cert_data(
+                    getattr(tls_config, 'client_key', None)
+                ) if getattr(tls_config, 'client_key', None) else None
+
             # Update client hello with new configuration
             # For TLS 1.3, record layer version stays 0x0303 for compatibility
             client_hello_version = self.tls_version
@@ -674,9 +681,40 @@ class TLS:
             self._key_exchange_type = 'RSA'
             debug(f"RSA key exchange for cipher suite 0x{cipher_suite:04X}")
 
-    def _parse_certificate_request(self, _data):
-        """Parse CertificateRequest message"""
+    def _parse_certificate_request(self, data):
+        """
+        Parse CertificateRequest message.
+        Extracts certificate types, signature algorithms, and distinguished names.
+        """
         self._client_cert_requested = True
+        offset = 0
+
+        # certificate_types (1-byte length + types)
+        if offset < len(data):
+            cert_types_len = data[offset]
+            offset += 1
+            self._cert_types = list(data[offset:offset + cert_types_len])
+            offset += cert_types_len
+            debug(f"CertificateRequest: cert_types={self._cert_types}")
+
+        # signature_algorithms (2-byte length + algorithms)
+        if offset + 2 <= len(data):
+            sig_algs_len = struct.unpack("!H", data[offset:offset + 2])[0]
+            offset += 2
+            self._cert_sig_algs = []
+            for i in range(0, sig_algs_len, 2):
+                if offset + 2 <= len(data):
+                    self._cert_sig_algs.append(
+                        struct.unpack("!H", data[offset:offset + 2])[0]
+                    )
+                    offset += 2
+            debug(f"CertificateRequest: sig_algs={[hex(a) for a in self._cert_sig_algs]}")
+
+        # distinguished_names (2-byte length + DN list) — optional, often empty
+        if offset + 2 <= len(data):
+            dn_len = struct.unpack("!H", data[offset:offset + 2])[0]
+            offset += 2
+            self._cert_dn_data = data[offset:offset + dn_len]
 
     def _parse_server_hello_done(self, _data):
         """Parse ServerHelloDone message"""
@@ -688,11 +726,17 @@ class TLS:
         """
         Send client finishing messages
         """
-        # Send empty Certificate if requested
-        if hasattr(self, '_client_cert_requested'):
-            empty_cert = self._build_empty_certificate()
-            self.conn.sendall(empty_cert)
-            debug("Sent empty Certificate")
+        # Send Certificate if requested
+        if getattr(self, '_client_cert_requested', False):
+            client_cert_pem = getattr(self, '_client_cert_pem', None)
+            if client_cert_pem:
+                cert_msg = self._build_client_certificate(client_cert_pem)
+                self.conn.sendall(cert_msg)
+                debug("Sent client Certificate")
+            else:
+                empty_cert = self._build_empty_certificate()
+                self.conn.sendall(empty_cert)
+                debug("Sent empty Certificate (no client cert configured)")
 
         # Send ClientKeyExchange
         client_key_exchange = self._build_client_key_exchange()
@@ -803,13 +847,65 @@ class TLS:
             debug(f"Failed to wait for server handshake completion: {e}")
             return False
 
+    @staticmethod
+    def _load_cert_data(cert_input):
+        """Load certificate/key data from file path or raw bytes/string."""
+        if cert_input is None:
+            return None
+        if isinstance(cert_input, bytes):
+            return cert_input
+        if isinstance(cert_input, str):
+            import os  # pylint: disable=import-outside-toplevel
+            if os.path.isfile(cert_input):
+                with open(cert_input, 'rb') as f:
+                    return f.read()
+            return cert_input.encode('utf-8')
+        return None
+
     def _build_empty_certificate(self):
         """Build an empty certificate message"""
-        # Certificate message with empty certificate list
         cert_list_length = b'\x00\x00\x00'  # 0 length certificate list
         cert_msg = b'\x0b' + struct.pack("!I", 3)[1:] + cert_list_length
+        record = b'\x16\x03\x03' + struct.pack("!H", len(cert_msg)) + cert_msg
+        return record
 
-        # Wrap in TLS record
+    def _build_client_certificate(self, cert_pem):
+        """
+        Build a Certificate message with the client's certificate.
+        Parses PEM to extract DER-encoded certificate(s).
+        """
+        import base64  # pylint: disable=import-outside-toplevel
+
+        # Extract DER certificates from PEM
+        certs_der = []
+        if isinstance(cert_pem, bytes):
+            cert_pem = cert_pem.decode('utf-8', errors='replace')
+
+        in_cert = False
+        cert_lines = []
+        for line in cert_pem.splitlines():
+            if '-----BEGIN CERTIFICATE-----' in line:
+                in_cert = True
+                cert_lines = []
+            elif '-----END CERTIFICATE-----' in line:
+                in_cert = False
+                der = base64.b64decode(''.join(cert_lines))
+                certs_der.append(der)
+            elif in_cert:
+                cert_lines.append(line.strip())
+
+        if not certs_der:
+            return self._build_empty_certificate()
+
+        # Build certificate list: each cert is 3-byte length + DER data
+        cert_list = b""
+        for der in certs_der:
+            cert_list += struct.pack("!I", len(der))[1:] + der  # 3-byte length
+
+        # Certificate message: type(11) + 3-byte total length + 3-byte list length + certs
+        list_length = struct.pack("!I", len(cert_list))[1:]
+        cert_msg = b'\x0b' + struct.pack("!I", len(cert_list) + 3)[1:] + list_length + cert_list
+
         record = b'\x16\x03\x03' + struct.pack("!H", len(cert_msg)) + cert_msg
         return record
 

--- a/ja3requests/protocol/tls/config.py
+++ b/ja3requests/protocol/tls/config.py
@@ -76,6 +76,10 @@ class TlsConfig:
         self._h2_settings = None
         self._h2_window_update = None
 
+        # Client certificate for mutual TLS
+        self._client_cert = None  # PEM-encoded certificate bytes or file path
+        self._client_key = None   # PEM-encoded private key bytes or file path
+
     @property
     def tls_version(self) -> int:
         """Get TLS version"""
@@ -263,6 +267,26 @@ class TlsConfig:
     def h2_window_update(self, value):
         """Set HTTP/2 initial WINDOW_UPDATE increment."""
         self._h2_window_update = value
+
+    @property
+    def client_cert(self):
+        """Get client certificate path or PEM data."""
+        return self._client_cert
+
+    @client_cert.setter
+    def client_cert(self, value):
+        """Set client certificate (file path or PEM bytes)."""
+        self._client_cert = value
+
+    @property
+    def client_key(self):
+        """Get client private key path or PEM data."""
+        return self._client_key
+
+    @client_key.setter
+    def client_key(self, value):
+        """Set client private key (file path or PEM bytes)."""
+        self._client_key = value
 
     def get_cipher_suite_values(self) -> List[int]:
         """Get cipher suite values as integers for JA3 fingerprint"""

--- a/test/test_remaining.py
+++ b/test/test_remaining.py
@@ -1,0 +1,231 @@
+"""Tests for remaining tasks: cookies crash fix, client cert, HPACK dynamic table."""
+
+import os
+import struct
+import socket
+import unittest
+
+from ja3requests.base.__sessions import BaseSession
+from ja3requests.cookies import Ja3RequestsCookieJar
+from ja3requests.protocol.tls.config import TlsConfig
+from ja3requests.protocol.h2.hpack import HPACKEncoder, HPACKDecoder
+
+
+class TestCookiesPropertySafety(unittest.TestCase):
+    """Test BaseSession.cookies doesn't crash when Request/response is None."""
+
+    def test_cookies_with_none_request(self):
+        s = BaseSession()
+        # Request is None by default
+        self.assertIsNone(s._request)
+        cookies = s.cookies
+        self.assertIsInstance(cookies, Ja3RequestsCookieJar)
+
+    def test_cookies_with_none_response(self):
+        s = BaseSession()
+        s._request = type('MockReq', (), {'cookies': None})()
+        self.assertIsNone(s._response)
+        cookies = s.cookies
+        self.assertIsInstance(cookies, Ja3RequestsCookieJar)
+
+    def test_cookies_with_session_cookies(self):
+        s = BaseSession()
+        s._cookies.set("a", "1")
+        cookies = s.cookies
+        self.assertEqual(cookies.get("a"), "1")
+
+    def test_cookies_merges_all_sources(self):
+        s = BaseSession()
+        s._cookies.set("session", "s1")
+        s._request = type('MockReq', (), {'cookies': {"request": "r1"}})()
+        s._response = type('MockResp', (), {'cookies': Ja3RequestsCookieJar()})()
+        cookies = s.cookies
+        self.assertEqual(cookies.get("session"), "s1")
+
+
+class TestClientCertConfig(unittest.TestCase):
+    """Test TlsConfig client certificate properties."""
+
+    def test_default_no_cert(self):
+        config = TlsConfig()
+        self.assertIsNone(config.client_cert)
+        self.assertIsNone(config.client_key)
+
+    def test_set_cert_path(self):
+        config = TlsConfig()
+        config.client_cert = "/path/to/cert.pem"
+        config.client_key = "/path/to/key.pem"
+        self.assertEqual(config.client_cert, "/path/to/cert.pem")
+        self.assertEqual(config.client_key, "/path/to/key.pem")
+
+    def test_set_cert_bytes(self):
+        config = TlsConfig()
+        config.client_cert = b"-----BEGIN CERTIFICATE-----\n..."
+        self.assertIsInstance(config.client_cert, bytes)
+
+
+class TestClientCertParsing(unittest.TestCase):
+    """Test TLS CertificateRequest parsing."""
+
+    def test_parse_certificate_request(self):
+        from ja3requests.protocol.tls import TLS
+
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1)
+
+            # Build CertificateRequest: cert_types + sig_algs + distinguished_names
+            cert_types = b"\x02\x01\x40"  # 2 types: RSA(1), ECDSA(64)
+            sig_algs = struct.pack("!H", 4) + struct.pack("!HH", 0x0401, 0x0501)
+            dn_list = struct.pack("!H", 0)  # empty DN list
+            data = cert_types + sig_algs + dn_list
+
+            tls._parse_certificate_request(data)
+            self.assertTrue(tls._client_cert_requested)
+            self.assertEqual(tls._cert_types, [1, 64])
+            self.assertEqual(tls._cert_sig_algs, [0x0401, 0x0501])
+        finally:
+            s1.close()
+            s2.close()
+
+
+class TestClientCertBuilding(unittest.TestCase):
+    """Test building client certificate message."""
+
+    def test_build_empty_certificate(self):
+        from ja3requests.protocol.tls import TLS
+
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1)
+            msg = tls._build_empty_certificate()
+            # Should be a TLS record with handshake type 11
+            self.assertEqual(msg[0], 0x16)  # Handshake
+            self.assertEqual(msg[5], 0x0b)  # Certificate type
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_build_client_certificate_from_pem(self):
+        from ja3requests.protocol.tls import TLS
+        import base64
+
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1)
+            # Fake DER certificate
+            fake_der = os.urandom(256)
+            fake_pem = (
+                b"-----BEGIN CERTIFICATE-----\n"
+                + base64.b64encode(fake_der)
+                + b"\n-----END CERTIFICATE-----\n"
+            )
+            msg = tls._build_client_certificate(fake_pem)
+            self.assertEqual(msg[0], 0x16)  # Handshake
+            self.assertEqual(msg[5], 0x0b)  # Certificate type
+            # Should contain the DER cert
+            self.assertIn(fake_der, msg)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_build_client_certificate_bad_pem_returns_empty(self):
+        from ja3requests.protocol.tls import TLS
+
+        s1, s2 = socket.socketpair()
+        try:
+            tls = TLS(s1)
+            msg = tls._build_client_certificate(b"not a valid PEM")
+            # Should fall back to empty certificate
+            self.assertEqual(msg[5], 0x0b)
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_load_cert_data_bytes(self):
+        from ja3requests.protocol.tls import TLS
+        result = TLS._load_cert_data(b"raw bytes")
+        self.assertEqual(result, b"raw bytes")
+
+    def test_load_cert_data_none(self):
+        from ja3requests.protocol.tls import TLS
+        result = TLS._load_cert_data(None)
+        self.assertIsNone(result)
+
+    def test_load_cert_data_string(self):
+        from ja3requests.protocol.tls import TLS
+        result = TLS._load_cert_data("string data")
+        self.assertEqual(result, b"string data")
+
+
+class TestHPACKDynamicTable(unittest.TestCase):
+    """Test HPACK encoder uses dynamic table for compression."""
+
+    def test_repeated_header_uses_dynamic_table(self):
+        enc = HPACKEncoder()
+        dec = HPACKDecoder()
+
+        headers = [("x-custom", "value1")]
+        # First encoding: literal with incremental indexing
+        encoded1 = enc.encode_headers(headers)
+        # Should have added to dynamic table
+        self.assertEqual(len(enc.dynamic_table), 1)
+        self.assertEqual(enc.dynamic_table[0], ("x-custom", "value1"))
+
+        # Second encoding of same header: should use indexed representation
+        encoded2 = enc.encode_headers(headers)
+        # Indexed encoding is shorter than literal
+        self.assertLess(len(encoded2), len(encoded1))
+
+        # Both should decode correctly
+        decoded1 = dec.decode_headers(encoded1)
+        self.assertEqual(decoded1, [("x-custom", "value1")])
+
+    def test_sensitive_headers_not_indexed(self):
+        enc = HPACKEncoder()
+        enc.encode_headers([("authorization", "Bearer token123")])
+        # Sensitive headers should NOT be added to dynamic table
+        self.assertEqual(len(enc.dynamic_table), 0)
+
+    def test_cookie_not_indexed(self):
+        enc = HPACKEncoder()
+        enc.encode_headers([("cookie", "session=abc")])
+        self.assertEqual(len(enc.dynamic_table), 0)
+
+    def test_dynamic_table_eviction(self):
+        enc = HPACKEncoder()
+        # Fill dynamic table with large entries
+        for i in range(200):
+            enc.encode_headers([(f"x-header-{i}", f"value-{i}" * 10)])
+
+        # Table should not exceed max size
+        self.assertLessEqual(enc._dynamic_table_size, enc.MAX_DYNAMIC_TABLE_SIZE)
+
+    def test_encode_decode_roundtrip_with_dynamic(self):
+        enc = HPACKEncoder()
+        dec = HPACKDecoder()
+
+        all_headers = [
+            (":method", "GET"),
+            (":path", "/api/v1"),
+            ("accept", "application/json"),
+            ("x-request-id", "abc123"),
+        ]
+        encoded = enc.encode_headers(all_headers)
+        decoded = dec.decode_headers(encoded)
+        self.assertEqual(decoded, all_headers)
+
+    def test_dynamic_table_name_match(self):
+        """Same name, different value should use name index from dynamic table."""
+        enc = HPACKEncoder()
+        enc.encode_headers([("x-trace", "trace-1")])
+        self.assertEqual(len(enc.dynamic_table), 1)
+
+        # Same name, different value
+        encoded2 = enc.encode_headers([("x-trace", "trace-2")])
+        # Should use name index from dynamic table
+        self.assertEqual(len(enc.dynamic_table), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

### Bug fix
- **BaseSession.cookies crash**: `AttributeError` when accessing `.cookies` before any request was made (Request/response = None). Fixed with safe null checks.

### Client Certificate (mTLS)
- `TlsConfig.client_cert` / `client_key`: accept PEM file path or raw bytes
- `_parse_certificate_request()`: fully parse cert types, signature algorithms, distinguished names
- `_build_client_certificate()`: parse PEM → DER, build TLS Certificate message with cert chain
- Falls back to empty certificate when no client cert configured

### HPACK Dynamic Table
- Encoder now uses **incremental indexing** (0x40 prefix) for non-sensitive headers
- Repeated headers encoded as indexed references (significantly smaller)
- Sensitive headers (authorization, cookie) use **never-indexed** (0x10)
- Dynamic table eviction on overflow (RFC 7541 Section 4.1)

## Test plan
- [x] 20 new tests (cookies safety, client cert, CertificateRequest parsing, HPACK dynamic table)
- [x] 782 total tests pass

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL