### PR TITLE
feat: HTTP/2 connection pool with stream multiplexing (#33)

### DIFF
--- a/ja3requests/pool.py
+++ b/ja3requests/pool.py
@@ -3,6 +3,7 @@ Ja3Requests.pool
 ~~~~~~~~~~~~~~~~
 
 Thread-safe connection pooling for HTTP/HTTPS connections.
+Supports HTTP/1.1 serial reuse and HTTP/2 stream multiplexing.
 """
 
 import socket
@@ -33,6 +34,7 @@ class PooledConnection:
         self.created_at = created_at or time.time()
         self.last_used_at = self.created_at
         self.tls = None  # TLS context for HTTPS connections
+        self.negotiated_protocol: Optional[str] = None  # ALPN result ('h2', 'http/1.1', None)
 
     def __repr__(self) -> str:
         return f"<PooledConnection {self.scheme}://{self.host}:{self.port} alive={self.is_alive()}>"
@@ -46,15 +48,12 @@ class PooledConnection:
         try:
             if self.conn is None:
                 return False
-            # Try to check socket state without consuming data
             self.conn.setblocking(False)
             try:
-                # Peek at socket - if recv returns empty, connection is closed
                 data = self.conn.recv(1, socket.MSG_PEEK)
                 if data == b'':
                     return False
             except BlockingIOError:
-                # No data available but connection is alive
                 pass
             except (OSError, ConnectionError) as e:
                 debug(f"Connection check failed: {e}", level=2)
@@ -80,12 +79,85 @@ class PooledConnection:
         self.conn = None
 
 
+class PooledH2Connection(PooledConnection):
+    """
+    Pooled HTTP/2 connection with stream multiplexing support.
+
+    Unlike PooledConnection (one request at a time), a PooledH2Connection
+    can serve multiple concurrent streams up to the server's
+    SETTINGS_MAX_CONCURRENT_STREAMS.
+    """
+
+    def __init__(self, conn, scheme, host="", port=0, **kwargs):
+        super().__init__(conn, scheme, host, port, **kwargs)
+        self.negotiated_protocol = "h2"
+        self.h2_connection = None           # H2Connection instance
+        self._active_streams = 0
+        self._max_concurrent_streams = 100   # Conservative default
+        self._goaway_received = False
+        self._stream_lock = threading.RLock()
+
+    @property
+    def active_streams(self) -> int:
+        """Number of active streams on this connection."""
+        with self._stream_lock:
+            return self._active_streams
+
+    def set_max_concurrent_streams(self, value: int):
+        """Update max concurrent streams from server's SETTINGS frame."""
+        with self._stream_lock:
+            self._max_concurrent_streams = value
+
+    def mark_goaway(self):
+        """Mark this connection as no longer accepting new streams (GOAWAY received)."""
+        with self._stream_lock:
+            self._goaway_received = True
+
+    def can_allocate_stream(self) -> bool:
+        """Check if a new stream can be allocated on this connection."""
+        with self._stream_lock:
+            if self._goaway_received:
+                return False
+            return self._active_streams < self._max_concurrent_streams
+
+    def acquire_stream(self) -> bool:
+        """Reserve a stream slot. Returns True if successful."""
+        with self._stream_lock:
+            if not self.can_allocate_stream():
+                return False
+            self._active_streams += 1
+            self.touch()
+            return True
+
+    def release_stream(self):
+        """Release a stream slot after a request completes."""
+        with self._stream_lock:
+            if self._active_streams > 0:
+                self._active_streams -= 1
+            self.touch()
+
+    def is_idle(self) -> bool:
+        """Check if connection has no active streams."""
+        with self._stream_lock:
+            return self._active_streams == 0
+
+    def __repr__(self) -> str:
+        return (
+            f"<PooledH2Connection {self.scheme}://{self.host}:{self.port} "
+            f"streams={self._active_streams}/{self._max_concurrent_streams} "
+            f"goaway={self._goaway_received}>"
+        )
+
+
 class ConnectionPool:
     """
     Thread-safe connection pool for HTTP/HTTPS connections.
 
     Maintains separate pools for each (host, port, scheme) combination.
-    Supports connection reuse, idle timeout, and maximum connections per host.
+    Supports:
+    - HTTP/1.1 serial reuse (one request per connection at a time)
+    - HTTP/2 stream multiplexing (multiple concurrent requests per connection)
+    - Connection reuse, idle timeout, maximum connections per host
     """
 
     def __init__(
@@ -103,6 +175,8 @@ class ConnectionPool:
             max_pool_size: Maximum total connections across all hosts
         """
         self._pools: Dict[Tuple[str, int, str], deque] = {}
+        # H2 connections kept separately (not popped on checkout)
+        self._h2_pools: Dict[Tuple[str, int, str], list] = {}
         self._lock = threading.RLock()
         self._max_per_host = max_connections_per_host
         self._idle_timeout = idle_timeout
@@ -116,19 +190,74 @@ class ConnectionPool:
         """Generate pool key from connection parameters"""
         return (host.lower(), port, scheme.lower())
 
+    def get_h2_connection(
+        self, host: str, port: int, scheme: str = "https"
+    ) -> Optional[PooledH2Connection]:
+        """
+        Get an HTTP/2 connection with available stream capacity.
+
+        Does NOT remove the connection from the pool — H2 connections
+        can serve multiple concurrent streams.
+
+        Returns None if no H2 connection has capacity.
+        """
+        key = self._get_pool_key(host, port, scheme)
+
+        with self._lock:
+            conns = self._h2_pools.get(key, [])
+            # Prune dead/expired connections
+            valid = []
+            for c in conns:
+                if c.is_expired(self._idle_timeout) or not c.is_alive():
+                    c.close()
+                    self._total_connections -= 1
+                    continue
+                valid.append(c)
+            self._h2_pools[key] = valid
+
+            # Find connection with stream capacity
+            for c in valid:
+                if c.acquire_stream():
+                    return c
+            return None
+
+    def put_h2_connection(
+        self, host: str, port: int, scheme: str, conn: Any, *, tls: Any = None,
+        h2_connection: Any = None,
+    ) -> Optional[PooledH2Connection]:
+        """
+        Register a new HTTP/2 connection in the pool.
+
+        Returns the PooledH2Connection wrapper, or None if pool is full.
+        The caller should call `acquire_stream()` before using.
+        """
+        key = self._get_pool_key(host, port, scheme)
+
+        with self._lock:
+            if self._total_connections >= self._max_pool_size:
+                debug(f"Pool full ({self._total_connections}/{self._max_pool_size})")
+                return None
+
+            if key not in self._h2_pools:
+                self._h2_pools[key] = []
+
+            pooled = PooledH2Connection(conn, scheme, host, port)
+            pooled.tls = tls
+            pooled.h2_connection = h2_connection
+            self._h2_pools[key].append(pooled)
+            self._total_connections += 1
+            return pooled
+
+    def release_h2_stream(self, pooled_conn: PooledH2Connection):
+        """Release a stream on an H2 connection. Connection stays in pool."""
+        pooled_conn.release_stream()
+
     def get_connection(
         self, host: str, port: int, scheme: str = "https"
     ) -> Optional[PooledConnection]:
         """
-        Get a connection from the pool if available.
-
-        Args:
-            host: Target hostname
-            port: Target port
-            scheme: Connection scheme (http/https)
-
-        Returns:
-            PooledConnection if available, None otherwise
+        Get an HTTP/1.1 connection from the pool if available.
+        Removes the connection (serial reuse).
         """
         key = self._get_pool_key(host, port, scheme)
 
@@ -138,11 +267,9 @@ class ConnectionPool:
 
             pool = self._pools[key]
 
-            # Try to find a valid connection
             while pool:
                 pooled_conn = pool.popleft()
 
-                # Check if connection is still usable
                 if pooled_conn.is_expired(self._idle_timeout):
                     pooled_conn.close()
                     self._total_connections -= 1
@@ -153,7 +280,6 @@ class ConnectionPool:
                     self._total_connections -= 1
                     continue
 
-                # Found a valid connection
                 pooled_conn.touch()
                 return pooled_conn
 
@@ -170,15 +296,7 @@ class ConnectionPool:
         pooled_conn: Optional['PooledConnection'] = None,
     ) -> bool:
         """
-        Return a connection to the pool for reuse.
-
-        Args:
-            host: Target hostname
-            port: Target port
-            scheme: Connection scheme
-            conn: Socket connection object
-            tls: TLS context (for HTTPS connections)
-            pooled_conn: Existing PooledConnection wrapper (for reused connections)
+        Return an HTTP/1.1 connection to the pool for reuse.
 
         Returns:
             True if connection was pooled, False if pool is full
@@ -191,13 +309,11 @@ class ConnectionPool:
 
             pool = self._pools[key]
 
-            # If returning an existing pooled connection, just add it back
             if pooled_conn is not None:
                 pooled_conn.touch()
                 pool.append(pooled_conn)
                 return True
 
-            # Check pool limits for new connections
             if self._total_connections >= self._max_pool_size:
                 debug(
                     f"Pool full ({self._total_connections}/{self._max_pool_size}), rejecting connection"
@@ -210,7 +326,6 @@ class ConnectionPool:
                 )
                 return False
 
-            # Create new pooled connection wrapper
             new_pooled_conn = PooledConnection(conn, scheme, host, port)
             new_pooled_conn.tls = tls
             new_pooled_conn.touch()
@@ -240,6 +355,20 @@ class ConnectionPool:
                 else:
                     del self._pools[key]
 
+            # Also close idle H2 connections (only if no active streams)
+            for key, conns in list(self._h2_pools.items()):
+                kept = []
+                for c in conns:
+                    if c.is_expired(self._idle_timeout) and c.is_idle():
+                        c.close()
+                        self._total_connections -= 1
+                    else:
+                        kept.append(c)
+                if kept:
+                    self._h2_pools[key] = kept
+                else:
+                    del self._h2_pools[key]
+
     def close_host_connections(self, host: str, port: int, scheme: str):
         """Close all connections to a specific host"""
         key = self._get_pool_key(host, port, scheme)
@@ -250,6 +379,11 @@ class ConnectionPool:
                 for pooled_conn in pool:
                     pooled_conn.close()
                     self._total_connections -= 1
+            if key in self._h2_pools:
+                conns = self._h2_pools.pop(key)
+                for c in conns:
+                    c.close()
+                    self._total_connections -= 1
 
     def close_all(self):
         """Close all pooled connections"""
@@ -257,8 +391,12 @@ class ConnectionPool:
             for pool in self._pools.values():
                 for pooled_conn in pool:
                     pooled_conn.close()
+            for conns in self._h2_pools.values():
+                for c in conns:
+                    c.close()
 
             self._pools.clear()
+            self._h2_pools.clear()
             self._total_connections = 0
 
     def get_stats(self) -> Dict:
@@ -267,14 +405,23 @@ class ConnectionPool:
             stats = {
                 "total_connections": self._total_connections,
                 "pools": len(self._pools),
+                "h2_pools": len(self._h2_pools),
                 "max_per_host": self._max_per_host,
                 "idle_timeout": self._idle_timeout,
                 "hosts": {},
+                "h2_hosts": {},
             }
 
             for key, pool in self._pools.items():
                 host, port, scheme = key
                 stats["hosts"][f"{scheme}://{host}:{port}"] = len(pool)
+
+            for key, conns in self._h2_pools.items():
+                host, port, scheme = key
+                stats["h2_hosts"][f"{scheme}://{host}:{port}"] = {
+                    "connections": len(conns),
+                    "active_streams": sum(c.active_streams for c in conns),
+                }
 
             return stats
 

--- a/test/test_h2_pool.py
+++ b/test/test_h2_pool.py
@@ -1,0 +1,234 @@
+"""Tests for HTTP/2 connection pool multiplexing (#33)."""
+
+import threading
+import unittest
+
+from ja3requests.pool import (
+    ConnectionPool,
+    PooledConnection,
+    PooledH2Connection,
+    get_default_pool,
+)
+
+
+class FakeSocket:
+    """Fake socket that pretends to be alive."""
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def recv(self, n, flags=0):
+        return b"\x00"  # Pretend alive
+
+    def setblocking(self, val):
+        pass
+
+
+class TestPooledH2Connection(unittest.TestCase):
+    """Test PooledH2Connection stream management."""
+
+    def test_initial_state(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        self.assertEqual(pc.active_streams, 0)
+        self.assertEqual(pc.negotiated_protocol, "h2")
+        self.assertTrue(pc.can_allocate_stream())
+        self.assertTrue(pc.is_idle())
+
+    def test_acquire_stream(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        self.assertTrue(pc.acquire_stream())
+        self.assertEqual(pc.active_streams, 1)
+        self.assertFalse(pc.is_idle())
+
+    def test_release_stream(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        pc.acquire_stream()
+        pc.acquire_stream()
+        self.assertEqual(pc.active_streams, 2)
+        pc.release_stream()
+        self.assertEqual(pc.active_streams, 1)
+        pc.release_stream()
+        self.assertEqual(pc.active_streams, 0)
+        self.assertTrue(pc.is_idle())
+
+    def test_release_below_zero_safe(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        pc.release_stream()  # Should not go negative
+        self.assertEqual(pc.active_streams, 0)
+
+    def test_max_concurrent_streams(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        pc.set_max_concurrent_streams(3)
+        self.assertTrue(pc.acquire_stream())
+        self.assertTrue(pc.acquire_stream())
+        self.assertTrue(pc.acquire_stream())
+        self.assertFalse(pc.acquire_stream())  # At limit
+        self.assertFalse(pc.can_allocate_stream())
+
+    def test_goaway_blocks_new_streams(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        pc.acquire_stream()
+        pc.mark_goaway()
+        self.assertFalse(pc.can_allocate_stream())
+        self.assertFalse(pc.acquire_stream())
+
+    def test_repr(self):
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        r = repr(pc)
+        self.assertIn("PooledH2Connection", r)
+        self.assertIn("streams=0/", r)
+
+    def test_thread_safe_acquire(self):
+        """Concurrent acquires should not exceed the limit."""
+        pc = PooledH2Connection(FakeSocket(), "https", "example.com", 443)
+        pc.set_max_concurrent_streams(50)
+
+        acquired_count = [0]
+        lock = threading.Lock()
+
+        def worker():
+            for _ in range(10):
+                if pc.acquire_stream():
+                    with lock:
+                        acquired_count[0] += 1
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Total attempts: 200, limit: 50
+        self.assertLessEqual(acquired_count[0], 50)
+        self.assertEqual(pc.active_streams, acquired_count[0])
+
+
+class TestH2ConnectionPool(unittest.TestCase):
+    """Test H2 multiplexing in ConnectionPool."""
+
+    def test_put_h2_connection(self):
+        pool = ConnectionPool()
+        pc = pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+        self.assertIsNotNone(pc)
+        self.assertEqual(pc.negotiated_protocol, "h2")
+
+    def test_get_h2_connection_acquires_stream(self):
+        pool = ConnectionPool()
+        pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+
+        pc = pool.get_h2_connection("example.com", 443, "https")
+        self.assertIsNotNone(pc)
+        self.assertEqual(pc.active_streams, 1)
+
+    def test_get_h2_connection_stays_in_pool(self):
+        """H2 connections are NOT removed on get (multiplexing)."""
+        pool = ConnectionPool()
+        pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+
+        pc1 = pool.get_h2_connection("example.com", 443, "https")
+        pc2 = pool.get_h2_connection("example.com", 443, "https")
+        # Should get the same underlying connection twice (multiplexed)
+        self.assertIs(pc1, pc2)
+        self.assertEqual(pc1.active_streams, 2)
+
+    def test_get_h2_connection_none_when_empty(self):
+        pool = ConnectionPool()
+        self.assertIsNone(pool.get_h2_connection("nothing.com", 443, "https"))
+
+    def test_release_h2_stream(self):
+        pool = ConnectionPool()
+        pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+        pc = pool.get_h2_connection("example.com", 443, "https")
+        self.assertEqual(pc.active_streams, 1)
+        pool.release_h2_stream(pc)
+        self.assertEqual(pc.active_streams, 0)
+
+    def test_full_multiplexing_lifecycle(self):
+        """100 concurrent requests share 1 connection."""
+        pool = ConnectionPool()
+        pool.put_h2_connection("api.com", 443, "https", FakeSocket())
+
+        streams = []
+        for _ in range(100):
+            pc = pool.get_h2_connection("api.com", 443, "https")
+            self.assertIsNotNone(pc)
+            streams.append(pc)
+
+        # All 100 should share the same underlying connection
+        first = streams[0]
+        for pc in streams:
+            self.assertIs(pc, first)
+
+        self.assertEqual(first.active_streams, 100)
+
+        # Release all
+        for pc in streams:
+            pool.release_h2_stream(pc)
+        self.assertEqual(first.active_streams, 0)
+
+    def test_goaway_connection_not_reused(self):
+        pool = ConnectionPool()
+        pc = pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+        pc.mark_goaway()
+
+        result = pool.get_h2_connection("example.com", 443, "https")
+        self.assertIsNone(result)
+
+    def test_pool_full_returns_none(self):
+        pool = ConnectionPool(max_pool_size=2)
+        pool.put_h2_connection("a.com", 443, "https", FakeSocket())
+        pool.put_h2_connection("b.com", 443, "https", FakeSocket())
+        result = pool.put_h2_connection("c.com", 443, "https", FakeSocket())
+        self.assertIsNone(result)
+
+    def test_h2_stats(self):
+        pool = ConnectionPool()
+        pool.put_h2_connection("example.com", 443, "https", FakeSocket())
+        pc = pool.get_h2_connection("example.com", 443, "https")
+        stats = pool.get_stats()
+        self.assertIn("h2_pools", stats)
+        self.assertIn("h2_hosts", stats)
+        host_stats = stats["h2_hosts"]["https://example.com:443"]
+        self.assertEqual(host_stats["connections"], 1)
+        self.assertEqual(host_stats["active_streams"], 1)
+        pool.release_h2_stream(pc)
+
+    def test_close_host_closes_h2(self):
+        pool = ConnectionPool()
+        sock = FakeSocket()
+        pool.put_h2_connection("example.com", 443, "https", sock)
+        pool.close_host_connections("example.com", 443, "https")
+        self.assertTrue(sock.closed)
+
+    def test_close_all_closes_h2(self):
+        pool = ConnectionPool()
+        sock = FakeSocket()
+        pool.put_h2_connection("example.com", 443, "https", sock)
+        pool.close_all()
+        self.assertTrue(sock.closed)
+
+
+class TestMixedPool(unittest.TestCase):
+    """Test that H1 and H2 pools coexist correctly."""
+
+    def test_h1_and_h2_separate(self):
+        pool = ConnectionPool()
+        sock1 = FakeSocket()
+        sock2 = FakeSocket()
+        pool.put_connection("example.com", 443, "https", sock1)
+        pool.put_h2_connection("example.com", 443, "https", sock2)
+
+        # H1 get should not return H2
+        h1_conn = pool.get_connection("example.com", 443, "https")
+        self.assertIsNotNone(h1_conn)
+        self.assertNotIsInstance(h1_conn, PooledH2Connection)
+
+        # H2 get should return H2
+        h2_conn = pool.get_h2_connection("example.com", 443, "https")
+        self.assertIsInstance(h2_conn, PooledH2Connection)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds HTTP/2 stream multiplexing to the connection pool — previously all connections were treated as serial (one request at a time).

### New class: `PooledH2Connection`
- Tracks active stream count
- Respects `SETTINGS_MAX_CONCURRENT_STREAMS`
- Thread-safe stream acquire/release
- GOAWAY handling: stops accepting new streams

### `ConnectionPool` enhancements
- Separate `_h2_pools` dict; H2 connections stay in pool across gets
- `get_h2_connection()` acquires a stream without removing connection
- `put_h2_connection()` registers new H2 connection
- `release_h2_stream()` decrements stream count
- `close_idle_connections()` only closes H2 conns with zero active streams
- Stats include active stream counts per host

### Impact
100 concurrent requests to the same host can now share a single TLS connection.

## Test plan
- [x] 20 new tests (stream acquire/release, thread safety, GOAWAY, mixed H1/H2)
- [x] 841 total tests pass

Closes #33

https://claude.ai/code/session_0166XxwX1MxeD9Va5rBUNoTL